### PR TITLE
fix: cloud shell tutorial pointing to wrong directory

### DIFF
--- a/cloud-run/docs/cloudshell-tutorial-maven.md
+++ b/cloud-run/docs/cloudshell-tutorial-maven.md
@@ -15,7 +15,7 @@ Ensure you have an active GCP account selected in the Cloud shell
 gcloud auth login
 ```
 
-Navigate to the 'deploy-apigee-proxy' directory in the Cloud shell.
+Navigate to the 'cloud-run' directory in the Cloud shell.
 
 ```sh
 cd cloud-run


### PR DESCRIPTION
Pointing to wrong directory in tutorial