### PR TITLE
fix: README curl command

### DIFF
--- a/deploy-apigee-proxy/README.md
+++ b/deploy-apigee-proxy/README.md
@@ -66,7 +66,7 @@ gcloud builds submit --config cloudbuild.yaml . \
 You can test the API call to make sure the deployment was successful
 
 ```bash
-curl -v -X GET https://$APIGEE_HOST/v1/samples/hello-cicd"
+curl -v -X GET https://$APIGEE_HOST/v1/samples/hello-cicd
 ```
 
 ## Cleanup


### PR DESCRIPTION
Removed trailing double-quote at the end of the curl command to test the proxy