### PR TITLE
Update cloudbuild.yaml

### DIFF
--- a/deploy-apigee-proxy/cloudbuild.yaml
+++ b/deploy-apigee-proxy/cloudbuild.yaml
@@ -43,4 +43,4 @@ steps:
         mvn -f pom.xml -ntp apigee-enterprise:deploy -Pdev -Dorg=$PROJECT_ID \
           -Denv=$_APIGEE_TEST_ENV -Dbearer=${build_token}
 options:
- logging: GCS_ONLY
+  logging: GCS_ONLY

--- a/deploy-apigee-proxy/cloudbuild.yaml
+++ b/deploy-apigee-proxy/cloudbuild.yaml
@@ -42,3 +42,5 @@ steps:
         source /workspace/build_vars &&
         mvn -f pom.xml -ntp apigee-enterprise:deploy -Pdev -Dorg=$PROJECT_ID \
           -Denv=$_APIGEE_TEST_ENV -Dbearer=${build_token}
+options:
+ logging: GCS_ONLY


### PR DESCRIPTION
add: cloud logging option so that cloudbuild.yaml can be used with cloud triggers when code is staged in a repo.  Without this cloud build complains that logging needs to be added.