### PR TITLE
fix: correct misformatting and bad link in cloud-functions README

### DIFF
--- a/cloud-functions/README.md
+++ b/cloud-functions/README.md
@@ -45,11 +45,12 @@ MacOS works; sorry, Powershell does not. This sample demonstrates how to connect
 to a Cloud Function from an Apigee Proxy.
 
 Make sure the following tools are available in your terminal's PATH
-    *[gcloud SDK](https://cloud.google.com/sdk/docs/install)
-    * unzip
-    *curl
-    * jq
-    * npm
+
+  * [gcloud SDK](https://cloud.google.com/sdk/docs/install)
+  * unzip
+  * curl
+  * jq
+  * npm
 
 Cloud Shell has all of these pre-configured. If you use your own machine, you
 will need to install these yourself.

--- a/cloud-functions/README.md
+++ b/cloud-functions/README.md
@@ -56,4 +56,4 @@ Cloud Shell has all of these pre-configured. If you use your own machine, you
 will need to install these yourself.
 
 After you've insured the pre-requisites are in order, you can get started. Follow the
-steps in [Manual-Steps.md](./Manual-Steps.sh).
+steps in [Manual-Steps.md](./Manual-Steps.md).


### PR DESCRIPTION
correct misformatting and bad link in cloud-functions README