### PR TITLE
fix: add excluded plugins to apigeelint commands

### DIFF
--- a/authorize-idp-access-tokens/package-lock.json
+++ b/authorize-idp-access-tokens/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@cucumber/cucumber": "^7.3.0",
         "apickli": "^3.0.1",
-        "apigeelint": "*"
+        "apigeelint": "latest"
       }
     },
     "node_modules/@cucumber/create-meta": {

--- a/authorize-idp-access-tokens/package.json
+++ b/authorize-idp-access-tokens/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "API proxy demonstrating the Authorization of JWT access tokens issued by an Identity Provider",
   "scripts": {
-   "lintapi": "apigeelint -s apiproxy -e PO013,PO025 -f table.js",
+   "lintapi": "apigeelint -s apiproxy -e PO013,PO025,TD004,TD002 -f table.js",
    "lintsf": "apigeelint -s sharedflowbundle -e PO013,PO025 -f table.js",
    "lint": "npm run lintapi && npm run lintsf",
    "test": "npx cucumber-js --publish-quiet test/",

--- a/basic-caching/package-lock.json
+++ b/basic-caching/package-lock.json
@@ -8,9 +8,9 @@
             "name": "basic-caching",
             "version": "1.0.0",
             "dependencies": {
-                "@cucumber/cucumber": "*",
-                "apickli": "*",
-                "apigeelint": "*"
+                "@cucumber/cucumber": "latest",
+                "apickli": "latest",
+                "apigeelint": "latest"
             }
         },
         "node_modules/@babel/runtime": {

--- a/basic-caching/package.json
+++ b/basic-caching/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "API proxy that demonstrates basic caching policies",
     "scripts": {
-     "lint": "apigeelint -s apiproxy -f table.js",
+     "lint": "apigeelint -s apiproxy -e TD004,TD002 -f table.js",
       "test": "npx cucumber-js --publish-quiet test/"
     },
     "dependencies": {

--- a/basic-quota/package.json
+++ b/basic-quota/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "API proxy that demonstrates a basic quota policy",
   "scripts": {
-   "lint": "apigeelint -s apiproxy -e PO013,PO025 -f table.js",
+   "lint": "apigeelint -s apiproxy -e PO013,PO025,PO034 -f table.js",
     "test": "npx cucumber-js --publish-quiet test/"
   },
   "dependencies": {


### PR DESCRIPTION
add a few exclusions to various directories, to avoid warnings from Apigeelint in megalinter. 