### PR TITLE
fix: show the use of the encoded cert and subject/iss DNs

### DIFF
--- a/mtls-northbound/README.md
+++ b/mtls-northbound/README.md
@@ -294,8 +294,11 @@ gcloud compute backend-services update ${BACKEND_SERVICE} \
   --custom-request-header="X-Client-Cert-Present:{client_cert_present}" \
   --custom-request-header="X-Client-Cert-Chain-Verified:{client_cert_chain_verified}" \
   --custom-request-header="X-Client-Cert-Error:{client_cert_error}" \
+  --custom-request-header="X-Client-Cert-Encoded:{client_cert_leaf}" \
   --custom-request-header="X-Client-Cert-Hash:{client_cert_sha256_fingerprint}" \
   --custom-request-header="X-Client-Cert-Serial-Number:{client_cert_serial_number}" \
+  --custom-request-header="X-Client-Cert-SubjectDN:{client_cert_subject_dn}" \
+  --custom-request-header="X-Client-Cert-IssuerDN:{client_cert_issuer_dn}" \
   --custom-request-header="X-Client-Cert-SPIFFE:{client_cert_spiffe_id}" \
   --custom-request-header="X-Client-Cert-URI-SANs:{client_cert_uri_sans}" \
   --custom-request-header="X-Client-Cert-DNSName-SANs:{client_cert_dnsname_sans}" \

--- a/mtls-northbound/docs/cloudshell-tutorial.md
+++ b/mtls-northbound/docs/cloudshell-tutorial.md
@@ -248,8 +248,11 @@ gcloud compute backend-services update ${BACKEND_SERVICE} \
   --custom-request-header="X-Client-Cert-Present:{client_cert_present}" \
   --custom-request-header="X-Client-Cert-Chain-Verified:{client_cert_chain_verified}" \
   --custom-request-header="X-Client-Cert-Error:{client_cert_error}" \
+  --custom-request-header="X-Client-Cert-Encoded:{client_cert_leaf}" \
   --custom-request-header="X-Client-Cert-Hash:{client_cert_sha256_fingerprint}" \
   --custom-request-header="X-Client-Cert-Serial-Number:{client_cert_serial_number}" \
+  --custom-request-header="X-Client-Cert-SubjectDN:{client_cert_subject_dn}" \
+  --custom-request-header="X-Client-Cert-IssuerDN:{client_cert_issuer_dn}" \
   --custom-request-header="X-Client-Cert-SPIFFE:{client_cert_spiffe_id}" \
   --custom-request-header="X-Client-Cert-URI-SANs:{client_cert_uri_sans}" \
   --custom-request-header="X-Client-Cert-DNSName-SANs:{client_cert_dnsname_sans}" \


### PR DESCRIPTION
I simply updated the README and the tutorial documentation to describe the additional custom headers that are now available: 
* client_cert_leaf
* client_cert_subject_dn
* client_cert_issuer_dn

I did not update the API proxy to emit this data in the payloads. In order to do that I'd have to re-implement the entire tutorial, and I didn't have time budget for that.  This doc update is just a way to tell people "you can get the Subject and Issuer DNs, or the full leaf cert if you want it." 

@kurtkanaskie for your review 