### PR TITLE
Touch-up on Cloud-logging sample

### DIFF
--- a/cloud-logging/README.md
+++ b/cloud-logging/README.md
@@ -67,7 +67,6 @@ directly to the sample proxy.
 
 5. You should ensure the Cloud Logging API is enabled in your GCP project, or that you have the permissions to enable the API in your project.
 
-
 ## (QuickStart) Setup using CloudShell
 
 Use the following GCP CloudShell tutorial, and follow the instructions.
@@ -86,11 +85,11 @@ your own.
    cd apigee-samples/cloud-logging
    ```
 
-2. Edit the `env.sh` and configure the ENV vars
+2. Edit the `env.sh` and configure the required environment variables:
 
    * `PROJECT` the project where your Apigee organization is located
-   * `APIGEE_HOST` the externally reachable hostname of the Apigee environment group that contains APIGEE_ENV
    * `APIGEE_ENV` the Apigee environment where the demo resources should be created
+   * `APIGEE_HOST` the externally reachable hostname of the Apigee environment group that contains APIGEE_ENV
 
    Now source the `env.sh` file
 
@@ -99,11 +98,13 @@ your own.
    ```
 
 3. Authenticate to Google Cloud, if you have not already done so in this shell.
+
    ```bash
    gcloud auth login
    ```
 
 4. Check the roles on your account:
+
    ```bash
    ./check-role.sh
    ```
@@ -117,19 +118,23 @@ your own.
     * `roles/apigee.apiAdminV2`
 
    ...then you can use this sample, but you need to insure some other person has enabled the Cloud
-   Logging API on your project.
+   Logging API on your project. We will check that the Logging API is enabled in the next step.
 
 5. Check that the logging API is enabled.
+
+Owners or Editors on a Google Cloud Project must enable individual services, for
+them to be available.  Let's check that the Logging API is enabled.
+
    ```bash
    ./check-required-services.sh
    ```
 
-   - If this indicates that the logging API is already enabled on the project, you can proceed.
+   * If this indicates that the logging API is already enabled on the project, you can proceed.
 
-   - If the logging API is not enabled, but you have editor or owner role (as shown in the previous
+   * If the logging API is not enabled, but you have editor or owner role (as shown in the previous
      step), then you will enable the logging API in the next step.
 
-   - If the logging API is not enabled, and you do not have editor or owner role, then you need to
+   * If the logging API is not enabled, and you do not have editor or owner role, then you need to
      stop, and find someone who can enable that API on your GCP project, before proceeding here.
 
 5. Deploy Apigee API proxy

--- a/cloud-logging/README.md
+++ b/cloud-logging/README.md
@@ -1,6 +1,7 @@
 # Cloud Logging
 
-This example explores how you can send custom logging messages from Apigee into [Google Cloud Logging](https://cloud.google.com/logging/docs/overview)
+This example explores how you can send custom logging messages from Apigee into
+[Google Cloud Logging](https://cloud.google.com/logging/docs/overview)
 
 ## About logging, analytics and other data collection mechanisms
 
@@ -10,13 +11,22 @@ But if you need per API-call specific logging of specific API request/response f
 
 ## How it works
 
-This simple API proxy is basically transparent and will hit a sample target endpoint. But, it will be configured to use [Google Authentication](https://cloud.google.com/apigee/docs/api-platform/security/google-auth/overview). The proxy will use credentials corresponding to the identity of a [service account](https://cloud.google.com/iam/docs/understanding-service-accounts) we'll create and that has permissions to create logging entries (`logging.logEntries.create`) in this project's Cloud Logging.
+This simple API proxy is basically a transparent pass-through. It will invoke a sample target endpoint. But, it is configured to send a log message to Cloud Logging, for each API request it handles.
+
+It is configured to use [Google Authentication](https://cloud.google.com/apigee/docs/api-platform/security/google-auth/overview). The proxy will use credentials corresponding to the identity of a [service account](https://cloud.google.com/iam/docs/understanding-service-accounts) we'll create and that has permissions to create logging entries (`logging.logEntries.create`) in this project's Cloud Logging.
 
 ## Implementation on Apigee
 
-The MessageLogging policy will be placed at the [PostClientFlow](https://cloud.google.com/apigee/docs/api-platform/fundamentals/what-are-flows#designingflowexecutionsequence-havingcodeexecuteaftertheclientreceivesyourproxysresponsewithapostclientflow). While one can add this policy to any point of the request or response flow, the PostClientFlow is typically the best place to add it because we'll have all the context of the call and it is executed after the actual API response is sent to the API client.
-As an example, we'll log flow variables, request content, response content, static values, etc. The policy is quite flexible in terms of what it can log.
-It is also worth noting that it is quite common to add the MessageLogging policy to Shared Flows for standardization across multiple APIs, but in this example it will be added directly to the sample proxy.
+The MessageLogging policy is attached in the
+[PostClientFlow](https://cloud.google.com/apigee/docs/api-platform/fundamentals/what-are-flows#designingflowexecutionsequence-havingcodeexecuteaftertheclientreceivesyourproxysresponsewithapostclientflow). While
+one can add this policy to any point of the request or response flow, the PostClientFlow is typically
+the best place to add a MessageLogging policy. At that point, the proxy will have all the context
+associated to the call, and, the log is written after the actual API response is sent to the API client,
+which means the client does not incur any latency associated to the log write.  In this example, the proxy will log
+flow variables, request content, response content, static values, etc. The policy is quite flexible in
+terms of what it can log.  It is also worth noting that it is quite common to add the MessageLogging
+policy to Shared Flows for standardization across multiple APIs. In this example, just for simplicity, it will be added
+directly to the sample proxy.
 
 ## Screencast
 
@@ -25,17 +35,38 @@ It is also worth noting that it is quite common to add the MessageLogging policy
 ## Prerequisites
 
 1. [Provision Apigee X](https://cloud.google.com/apigee/docs/api-platform/get-started/provisioning-intro)
+
 2. Configure [external access](https://cloud.google.com/apigee/docs/api-platform/get-started/configure-routing#external-access) for API traffic to your Apigee X instance
-3. Make sure the following tools are available in your terminal's $PATH (Cloud Shell has these preconfigured)
-    * [gcloud SDK](https://cloud.google.com/sdk/docs/install)
+
+3. A Linux-based shell with bash, and the following tools available in your terminal's $PATH:
+    * [gcloud CLI](https://cloud.google.com/sdk/docs/install)
     * unzip
     * curl
     * jq
     * npm
-4. Make sure you have all the relevant IAM roles for executing this script
+
+   Cloud Shell is sufficient, and has all of these preconfigured, but you can use your own workstation.
+
+4. Make sure your Google Cloud user has all the relevant IAM roles for executing this script
     * `roles/iam.serviceAccountCreator`
     * `roles/resourcemanager.projectIamAdmin`
     * `roles/apigee.apiAdminV2`
+
+   The way roles work in Google Cloud: think of them as a way to group a set of related permissions that are often used together. For example, the [iam.serviceAccountCreator role](https://cloud.google.com/compute/docs/access/iam#iam.serviceAccountCreator) grants these permissions:
+      * iam.serviceAccounts.create
+      * iam.serviceAccounts.get
+      * iam.serviceAccounts.list
+      * resourcemanager.projects.get
+      * resourcemanager.projects.list
+
+   A user that has project Owner or project Editor role has [thousands of
+   permissions](https://cloud.google.com/iam/docs/understanding-roles#basic),
+   including the above. If your user is not Editor or Owner, you will need an
+   Editor or Owner or other privileged account to grant the additional roles to
+   your user, before proceeding with this exercise.
+
+5. You should ensure the Cloud Logging API is enabled in your GCP project, or that you have the permissions to enable the API in your project.
+
 
 ## (QuickStart) Setup using CloudShell
 
@@ -43,39 +74,78 @@ Use the following GCP CloudShell tutorial, and follow the instructions.
 
 [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://ssh.cloud.google.com/cloudshell/open?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/apigee-samples&cloudshell_git_branch=main&cloudshell_workspace=.&cloudshell_tutorial=cloud-logging/docs/cloudshell-tutorial.md)
 
-## Setup instructions
+## Manual Setup instructions
+
+If you do not wish to use the Cloudshell tutorial link provided above, you can follow these steps, on
+your own.
 
 1. Clone the apigee-samples repo, and switch the cloud-logging directory
 
-```bash
-git clone https://github.com/GoogleCloudPlatform/apigee-samples.git
-cd apigee-samples/cloud-logging
-```
+   ```bash
+   git clone https://github.com/GoogleCloudPlatform/apigee-samples.git
+   cd apigee-samples/cloud-logging
+   ```
 
 2. Edit the `env.sh` and configure the ENV vars
 
-* `PROJECT` the project where your Apigee organization is located
-* `APIGEE_HOST` the externally reachable hostname of the Apigee environment group that contains APIGEE_ENV
-* `APIGEE_ENV` the Apigee environment where the demo resources should be created
+   * `PROJECT` the project where your Apigee organization is located
+   * `APIGEE_HOST` the externally reachable hostname of the Apigee environment group that contains APIGEE_ENV
+   * `APIGEE_ENV` the Apigee environment where the demo resources should be created
 
-Now source the `env.sh` file
+   Now source the `env.sh` file
 
-```bash
-source ./env.sh
-```
+   ```bash
+   source ./env.sh
+   ```
 
-3. Deploy Apigee API proxy
+3. Authenticate to Google Cloud, if you have not already done so in this shell.
+   ```bash
+   gcloud auth login
+   ```
 
-```bash
-./deploy-cloud-logging.sh
-```
+4. Check the roles on your account:
+   ```bash
+   ./check-role.sh
+   ```
+
+   This script will show your identity and the roles associated to your identity.
+
+   If you have editor or owner roles, you will be able to proceed. If you do not have these roles, but
+   you have these roles:
+    * `roles/iam.serviceAccountCreator`
+    * `roles/resourcemanager.projectIamAdmin`
+    * `roles/apigee.apiAdminV2`
+
+   ...then you can use this sample, but you need to insure some other person has enabled the Cloud
+   Logging API on your project.
+
+5. Check that the logging API is enabled.
+   ```bash
+   ./check-required-services.sh
+   ```
+
+   - If this indicates that the logging API is already enabled on the project, you can proceed.
+
+   - If the logging API is not enabled, but you have editor or owner role (as shown in the previous
+     step), then you will enable the logging API in the next step.
+
+   - If the logging API is not enabled, and you do not have editor or owner role, then you need to
+     stop, and find someone who can enable that API on your GCP project, before proceeding here.
+
+5. Deploy Apigee API proxy
+
+   ```bash
+   ./deploy-cloud-logging.sh
+   ```
+
+   You should see happy messages.
 
 ## Test the API & Logging
 
 Generate a few sample requests to the deployed API Proxy.
 
 ```bash
-curl  https://$APIGEE_HOST/v1/samples/cloud-logging
+curl -i https://$APIGEE_HOST/v1/samples/cloud-logging
 ```
 
 > _If you want, consider also checking the call in the [Debug](https://cloud.google.com/apigee/docs/api-platform/debug/trace) view_
@@ -86,11 +156,19 @@ After issuing some calls, let's confirm the configured variables / values set on
 gcloud logging read "logName=projects/$PROJECT/logs/apigee"
 ```
 
-Cloud Logging is quite powerful. Few free to navigate to its UI in the GCP Console (_Logging_ Product Page in the console) and explore additional features such as filters, custom searches, custom alerts and much more
+Cloud Logging is quite powerful. Few free to navigate to the [Logs Explorer UI
+in the GCP Console](https://console.cloud.google.com/logs/query) (_Logging_
+Product Page in the console) and explore additional features such as filters,
+custom searches, custom alerts, saved queries, and much more
+
+If you are so inclined, you can modify the apiproxy, introducing new policies,
+or modifying the existing MessageLogging policy. Re-deploy the updated version,
+and then re-run your tests, and re-examine the logs.
 
 ## Cleanup
 
-If you want to clean up the artifacts from this example in your Apigee Organization, first source your `env.sh` script, and then run
+If you want to clean up the artifacts from this example in your Apigee Organization, first source your
+`env.sh` script, and then run
 
 ```bash
 ./clean-up-cloud-logging.sh

--- a/cloud-logging/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
+++ b/cloud-logging/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='AM-Inject-Proxy-Revision-Header'>
+  <Set>
+    <Headers>
+      <Header name='apiproxy'>{apiproxy.name} r{apiproxy.revision}</Header>
+    </Headers>
+  </Set>
+</AssignMessage>

--- a/cloud-logging/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
+++ b/cloud-logging/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
@@ -1,3 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+ Copyright 2024 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
 <AssignMessage name='AM-Inject-Proxy-Revision-Header'>
   <Set>
     <Headers>

--- a/cloud-logging/apiproxy/policies/ML-CloudLogging.xml
+++ b/cloud-logging/apiproxy/policies/ML-CloudLogging.xml
@@ -11,7 +11,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<MessageLogging continueOnError="false" enabled="true" name="ML-CloudLogging">
+<MessageLogging name="ML-CloudLogging">
     <DisplayName>ML-CloudLogging</DisplayName>
     <CloudLogging>
         <LogName>projects/{organization.name}/logs/apigee</LogName>

--- a/cloud-logging/apiproxy/proxies/default.xml
+++ b/cloud-logging/apiproxy/proxies/default.xml
@@ -1,3 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+ Copyright 2023-2024 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
 <ProxyEndpoint name="default">
   <HTTPProxyConnection>
     <BasePath>/v1/samples/cloud-logging</BasePath>

--- a/cloud-logging/apiproxy/proxies/default.xml
+++ b/cloud-logging/apiproxy/proxies/default.xml
@@ -1,38 +1,35 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!--
- Copyright 2023 Google LLC
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-      http://www.apache.org/licenses/LICENSE-2.0
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 <ProxyEndpoint name="default">
-    <PreFlow name="PreFlow">
-        <Request/>
-        <Response/>
-    </PreFlow>
-    <Flows/>
-    <PostFlow name="PostFlow">
-        <Request/>
-        <Response/>
-    </PostFlow>
-    <PostClientFlow>
-        <Request/>
-        <Response>
-            <Step>
-                <Name>ML-CloudLogging</Name>
-            </Step>
-        </Response>
-    </PostClientFlow>
-    <HTTPProxyConnection>
-        <BasePath>/v1/samples/cloud-logging</BasePath>
-    </HTTPProxyConnection>
-    <RouteRule name="default">
-        <TargetEndpoint>default</TargetEndpoint>
-    </RouteRule>
+  <HTTPProxyConnection>
+    <BasePath>/v1/samples/cloud-logging</BasePath>
+  </HTTPProxyConnection>
+  <DefaultFaultRule>
+    <AlwaysEnforce>true</AlwaysEnforce>
+    <Step>
+      <Name>AM-Inject-Proxy-Revision-Header</Name>
+    </Step>
+  </DefaultFaultRule>
+  <PreFlow name="PreFlow">
+    <Request/>
+    <Response/>
+  </PreFlow>
+  <Flows/>
+  <PostFlow name="PostFlow">
+    <Request/>
+    <Response>
+      <Step>
+        <Name>AM-Inject-Proxy-Revision-Header</Name>
+      </Step>
+    </Response>
+  </PostFlow>
+  <PostClientFlow>
+    <Request/>
+    <Response>
+      <Step>
+        <Name>ML-CloudLogging</Name>
+      </Step>
+    </Response>
+  </PostClientFlow>
+  <RouteRule name="default">
+    <TargetEndpoint>default</TargetEndpoint>
+  </RouteRule>
 </ProxyEndpoint>

--- a/cloud-logging/check-required-services.sh
+++ b/cloud-logging/check-required-services.sh
@@ -18,11 +18,11 @@ source ./lib/utils.sh
 
 check_shell_variables
 
-SERVICES_OF_INTEREST=( "logging.googleapis.com" )
+SERVICES_OF_INTEREST=("logging.googleapis.com")
 for svc in "${SERVICES_OF_INTEREST[@]}"; do
-    if gcloud services list --enabled --project "$PROJECT" --format="value(config.name)" --filter="config.name=$svc" > /dev/null ; then
-        printf "%s ENABLED\n" "$svc"
-    else
-        printf "%s NOT ENABLED\n" "$svc"
-    fi
+  if gcloud services list --enabled --project "$PROJECT" --format="value(config.name)" --filter="config.name=$svc" >/dev/null; then
+    printf "%s ENABLED\n" "$svc"
+  else
+    printf "%s NOT ENABLED\n" "$svc"
+  fi
 done

--- a/cloud-logging/check-required-services.sh
+++ b/cloud-logging/check-required-services.sh
@@ -20,7 +20,7 @@ check_shell_variables
 
 SERVICES_OF_INTEREST=( "logging.googleapis.com" )
 for svc in "${SERVICES_OF_INTEREST[@]}"; do
-    if gcloud services list --enabled --project $PROJECT --format="value(config.name)" --filter="config.name=$svc" > /dev/null ; then
+    if gcloud services list --enabled --project "$PROJECT" --format="value(config.name)" --filter="config.name=$svc" > /dev/null ; then
         printf "%s ENABLED\n" "$svc"
     else
         printf "%s NOT ENABLED\n" "$svc"

--- a/cloud-logging/check-required-services.sh
+++ b/cloud-logging/check-required-services.sh
@@ -1,5 +1,6 @@
-#!/bin/sh
-# Copyright 2023-2024 Google LLC
+#!/bin/bash
+
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export PROJECT="<GCP_PROJECT_ID>"
-export APIGEE_ENV="<APIGEE_ENVIRONMENT_NAME>"
-export APIGEE_HOST="<APIGEE_DOMAIN_NAME>"
+source ./lib/utils.sh
 
-gcloud config set project $PROJECT
+check_shell_variables
+
+SERVICES_OF_INTEREST=( "logging.googleapis.com" )
+for svc in "${SERVICES_OF_INTEREST[@]}"; do
+    if gcloud services list --enabled --project $PROJECT --format="value(config.name)" --filter="config.name=$svc" > /dev/null ; then
+        printf "%s ENABLED\n" "$svc"
+    else
+        printf "%s NOT ENABLED\n" "$svc"
+    fi
+done

--- a/cloud-logging/check-role.sh
+++ b/cloud-logging/check-role.sh
@@ -24,6 +24,6 @@ gwho=$(gcloud auth list --filter=status:ACTIVE --format="value(account)")
 printf "Google Cloud identity: %s\n\n" "$gwho"
 
 gcloud projects get-iam-policy "$PROJECT" \
---flatten="bindings[].members" \
---format='table(bindings.role)' \
---filter="bindings.members:user:$gwho"
+  --flatten="bindings[].members" \
+  --format='table(bindings.role)' \
+  --filter="bindings.members:user:$gwho"

--- a/cloud-logging/check-role.sh
+++ b/cloud-logging/check-role.sh
@@ -1,5 +1,6 @@
-#!/bin/sh
-# Copyright 2023-2024 Google LLC
+#!/bin/bash
+
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export PROJECT="<GCP_PROJECT_ID>"
-export APIGEE_ENV="<APIGEE_ENVIRONMENT_NAME>"
-export APIGEE_HOST="<APIGEE_DOMAIN_NAME>"
+source ./lib/utils.sh
 
-gcloud config set project $PROJECT
+check_shell_variables
+
+# shellcheck disable=SC2002
+gwho=$(gcloud auth list --filter=status:ACTIVE --format="value(account)")
+
+printf "Google Cloud identity: %s\n\n" "$gwho"
+
+gcloud projects get-iam-policy "$PROJECT" \
+--flatten="bindings[].members" \
+--format='table(bindings.role)' \
+--filter="bindings.members:user:$gwho"

--- a/cloud-logging/clean-up-cloud-logging.sh
+++ b/cloud-logging/clean-up-cloud-logging.sh
@@ -53,9 +53,9 @@ MISSING_ENV_VARS=()
 [[ -z "$APIGEE_ENV" ]] && MISSING_ENV_VARS+=('APIGEE_ENV')
 
 [[ ${#MISSING_ENV_VARS[@]} -ne 0 ]] && {
-    printf -v joined '%s,' "${MISSING_ENV_VARS[@]}"
-    printf "You must set these environment variables: %s\n" "${joined%,}"
-    exit 1
+  printf -v joined '%s,' "${MISSING_ENV_VARS[@]}"
+  printf "You must set these environment variables: %s\n" "${joined%,}"
+  exit 1
 }
 
 TOKEN=$(gcloud auth print-access-token)
@@ -64,9 +64,8 @@ maybe_install_apigeecli
 
 delete_apiproxy "${PROXY_NAME}"
 
-
 printf "Removing IAM Policy Bindings\n"
-ROLES_OF_INTEREST=( "roles/logging.logWriter" )
+ROLES_OF_INTEREST=("roles/logging.logWriter")
 for role in "${ROLES_OF_INTEREST[@]}"; do
   printf "Checking role %s\n" "$role"
   # shellcheck disable=SC2207
@@ -81,15 +80,14 @@ for role in "${ROLES_OF_INTEREST[@]}"; do
   done
 done
 
-
 printf "Checking service account(s)\n"
-mapfile -t ARR < <(gcloud iam service-accounts list --project "$PROJECT" --format="value(email)" | grep $SA_BASE )
+mapfile -t ARR < <(gcloud iam service-accounts list --project "$PROJECT" --format="value(email)" | grep $SA_BASE)
 if [[ ${#ARR[@]} -gt 0 ]]; then
-    for sa in "${ARR[@]}"; do
-      printf "Deleting service account %s\n" "${sa}"
-      gcloud --quiet iam service-accounts delete "${sa}" --project "$PROJECT"
-    done
+  for sa in "${ARR[@]}"; do
+    printf "Deleting service account %s\n" "${sa}"
+    gcloud --quiet iam service-accounts delete "${sa}" --project "$PROJECT"
+  done
 else
-    printf "  No service accounts to delete.\n"
+  printf "  No service accounts to delete.\n"
 fi
 [[ -f "./.sa_name" ]] && rm -f ./.sa_name

--- a/cloud-logging/clean-up-cloud-logging.sh
+++ b/cloud-logging/clean-up-cloud-logging.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2023 Google LLC
+# Copyright 2023-2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,34 +14,82 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -z "$PROJECT" ]; then
-  echo "No PROJECT variable set"
-  exit
-fi
+SA_BASE="example-cloudlogger-sa-"
+PROXY_NAME="sample-cloud-logging"
 
-if [ -z "$APIGEE_ENV" ]; then
-  echo "No APIGEE_ENV variable set"
-  exit
-fi
+delete_apiproxy() {
+  local proxy_name=$1
+  local ENVNAME REV OUTFILE NUM_DEPLOYS
+  printf "Checking Proxy %s\n" "${proxy_name}"
+  if apigeecli apis get --name "$proxy_name" --org "$PROJECT" --token "$TOKEN" --disable-check >/dev/null 2>&1; then
+    OUTFILE=$(mktemp /tmp/apigee-samples.apigeecli.out.XXXXXX)
+    if apigeecli apis listdeploy --name "$proxy_name" --org "$PROJECT" --token "$TOKEN" --disable-check >"$OUTFILE" 2>&1; then
+      NUM_DEPLOYS=$(jq -r '.deployments | length' "$OUTFILE")
+      if [[ $NUM_DEPLOYS -ne 0 ]]; then
+        echo "Undeploying ${proxy_name}"
+        for ((i = 0; i < NUM_DEPLOYS; i++)); do
+          ENVNAME=$(jq -r ".deployments[$i].environment" "$OUTFILE")
+          REV=$(jq -r ".deployments[$i].revision" "$OUTFILE")
+          apigeecli apis undeploy --name "${proxy_name}" --env "$ENVNAME" --rev "$REV" --org "$PROJECT" --token "$TOKEN" --disable-check
+        done
+      else
+        printf "  There are no deployments of %s to remove.\n" "${proxy_name}"
+      fi
+    fi
+    [[ -f "$OUTFILE" ]] && rm "$OUTFILE"
 
-if [ -z "$APIGEE_HOST" ]; then
-  echo "No APIGEE_HOST variable set"
-  exit
-fi
+    echo "Deleting proxy ${proxy_name}"
+    apigeecli apis delete --name "${proxy_name}" --org "$PROJECT" --token "$TOKEN" --disable-check
+
+  else
+    printf "  The proxy %s does not exist.\n" "${proxy_name}"
+  fi
+}
+
+# ====================================================================
+
+MISSING_ENV_VARS=()
+[[ -z "$PROJECT" ]] && MISSING_ENV_VARS+=('PROJECT')
+[[ -z "$APIGEE_ENV" ]] && MISSING_ENV_VARS+=('APIGEE_ENV')
+
+[[ ${#MISSING_ENV_VARS[@]} -ne 0 ]] && {
+    printf -v joined '%s,' "${MISSING_ENV_VARS[@]}"
+    printf "You must set these environment variables: %s\n" "${joined%,}"
+    exit 1
+}
 
 TOKEN=$(gcloud auth print-access-token)
-SA_NAME=apigee-proxy-service-account
 
-echo "Installing apigeecli"
-curl -s https://raw.githubusercontent.com/apigee/apigeecli/main/downloadLatest.sh | bash
-export PATH=$PATH:$HOME/.apigeecli/bin
+maybe_install_apigeecli
 
-echo "Undeploying sample-cloud-logging proxy"
-REV=$(apigeecli envs deployments get --env "$APIGEE_ENV" --org "$PROJECT" --token "$TOKEN" --disable-check | jq .'deployments[]| select(.apiProxy=="sample-cloud-logging").revision' -r)
-apigeecli apis undeploy --name sample-cloud-logging --env "$APIGEE_ENV" --rev "$REV" --org "$PROJECT" --token "$TOKEN"
+delete_apiproxy "${PROXY_NAME}"
 
-echo "Deleting proxy sample-cloud-logging proxy"
-apigeecli apis delete --name sample-cloud-logging --org "$PROJECT" --token "$TOKEN"
 
-echo "Deleting service account"
-gcloud iam service-accounts delete ${SA_NAME}@"${PROJECT}".iam.gserviceaccount.com
+printf "Removing IAM Policy Bindings\n"
+ROLES_OF_INTEREST=( "roles/logging.logWriter" )
+for role in "${ROLES_OF_INTEREST[@]}"; do
+  printf "Checking role %s\n" "$role"
+  # shellcheck disable=SC2207
+  members=($(gcloud projects get-iam-policy "$PROJECT" --format=json |
+    jq --arg r "$role" '.bindings[] | select( .role == $r )' | jq --arg prefix "$SA_BASE" '.members[] | select(contains("serviceAccount:") and contains($prefix))' | sed -e 's/"//g'))
+
+  for member in "${members[@]}"; do
+    printf "  Removing IAM binding for %s\n" "$member"
+    gcloud projects remove-iam-policy-binding "${PROJECT}" \
+      --member="$member" \
+      --role="$role" >>/dev/null
+  done
+done
+
+
+printf "Checking service account(s)\n"
+mapfile -t ARR < <(gcloud iam service-accounts list --project "$PROJECT" --format="value(email)" | grep $SA_BASE )
+if [[ ${#ARR[@]} -gt 0 ]]; then
+    for sa in "${ARR[@]}"; do
+      printf "Deleting service account %s\n" "${sa}"
+      gcloud --quiet iam service-accounts delete "${sa}" --project "$PROJECT"
+    done
+else
+    printf "  No service accounts to delete.\n"
+fi
+[[ -f "./.sa_name" ]] && rm -f ./.sa_name

--- a/cloud-logging/deploy-cloud-logging.sh
+++ b/cloud-logging/deploy-cloud-logging.sh
@@ -15,7 +15,9 @@
 # limitations under the License.
 
 SA_BASE="example-cloudlogger-sa-"
+# shellcheck disable=SC2034
 PROXY_NAME="sample-cloud-logging"
+# shellcheck disable=SC2034
 scriptid="deploy-cloud-logging"
 
 source ./lib/utils.sh
@@ -24,12 +26,13 @@ source ./lib/utils.sh
 
 check_shell_variables
 
+# shellcheck disable=SC2034
 TOKEN=$(gcloud auth print-access-token)
 
 # check and maybe enable services
 SERVICES_OF_INTEREST=( "logging.googleapis.com" )
 for svc in "${SERVICES_OF_INTEREST[@]}"; do
-    if gcloud services list --enabled --project $PROJECT --format="value(config.name)" --filter="config.name=$svc" > /dev/null ; then
+    if gcloud services list --enabled --project "$PROJECT" --format="value(config.name)" --filter="config.name=$svc" > /dev/null ; then
         printf "%s is already enabled in the project...\n" "$svc"
     else
         printf "Attempting to enable %s...\n" "$svc"
@@ -58,6 +61,7 @@ printf "Creating and Deploying Apigee sample-cloud-logging proxy...\n"
 maybe_import_and_deploy ./apiproxy "$SA_EMAIL" "force"
 
 # wait outside of the fn, in case there were multiple deploys
+# shellcheck disable=SC2154
 if [[ $need_wait -eq 1 ]]; then
     printf "Waiting...\n"
     wait
@@ -65,6 +69,6 @@ fi
 
 printf "\nAll the Apigee artifacts are successfully deployed!\n\n"
 printf "Generate some calls with:\n"
-printf "  curl -i https://$APIGEE_HOST/v1/samples/cloud-logging\n\n"
+printf "  curl -i https://%s/v1/samples/cloud-logging\n\n" "$APIGEE_HOST"
 printf "After that, make sure you read the logs from Cloud Logging with\n"
-printf "  gcloud logging read \"logName=projects/$PROJECT/logs/apigee\"\n"
+printf "  gcloud logging read \"logName=projects/%s/logs/apigee\"\n" "$PROJECT"

--- a/cloud-logging/deploy-cloud-logging.sh
+++ b/cloud-logging/deploy-cloud-logging.sh
@@ -30,21 +30,20 @@ check_shell_variables
 TOKEN=$(gcloud auth print-access-token)
 
 # check and maybe enable services
-SERVICES_OF_INTEREST=( "logging.googleapis.com" )
+SERVICES_OF_INTEREST=("logging.googleapis.com")
 for svc in "${SERVICES_OF_INTEREST[@]}"; do
-    if gcloud services list --enabled --project "$PROJECT" --format="value(config.name)" --filter="config.name=$svc" > /dev/null ; then
-        printf "%s is already enabled in the project...\n" "$svc"
+  if gcloud services list --enabled --project "$PROJECT" --format="value(config.name)" --filter="config.name=$svc" >/dev/null; then
+    printf "%s is already enabled in the project...\n" "$svc"
+  else
+    printf "Attempting to enable %s...\n" "$svc"
+    if gcloud services enable logging --project="$PROJECT"; then
+      printf "  done.\n"
     else
-        printf "Attempting to enable %s...\n" "$svc"
-        if gcloud services enable logging --project="$PROJECT" ; then
-            printf "  done.\n"
-        else
-            printf "%s is not enabled, and the attempt to enable it failed. Cannot proceed.\n" "$svc"
-            exit 1
-        fi
+      printf "%s is not enabled, and the attempt to enable it failed. Cannot proceed.\n" "$svc"
+      exit 1
     fi
+  fi
 done
-
 
 # Creating and deleting an SA by the same name, repeatedly, can cause problems.
 # This uses a random factor to uniquify the SA name.
@@ -63,8 +62,8 @@ maybe_import_and_deploy ./apiproxy "$SA_EMAIL" "force"
 # wait outside of the fn, in case there were multiple deploys
 # shellcheck disable=SC2154
 if [[ $need_wait -eq 1 ]]; then
-    printf "Waiting...\n"
-    wait
+  printf "Waiting...\n"
+  wait
 fi
 
 printf "\nAll the Apigee artifacts are successfully deployed!\n\n"

--- a/cloud-logging/docs/cloudshell-tutorial.md
+++ b/cloud-logging/docs/cloudshell-tutorial.md
@@ -23,6 +23,10 @@ cd cloud-logging
 
 Edit the provided sample `env.sh` file, and set the environment variables there.
 
+   * `PROJECT` the project where your Apigee organization is located
+   * `APIGEE_ENV` the Apigee environment where the demo resources should be created
+   * `APIGEE_HOST` the externally reachable hostname of the Apigee environment group that contains APIGEE_ENV
+
 Click <walkthrough-editor-open-file filePath="cloud-logging/env.sh">here</walkthrough-editor-open-file> to open the file in the editor
 
 Then, source the `env.sh` file in the Cloud shell.
@@ -30,6 +34,47 @@ Then, source the `env.sh` file in the Cloud shell.
 ```sh
 source ./env.sh
 ```
+
+---
+
+## Check your role
+
+Check that your account has the necessary roles for this sample.
+
+```bash
+./check-role.sh
+```
+
+This script will show your identity and the roles associated to your identity.
+
+If you have editor or owner roles, you will be able to proceed. If you do not have these roles, but
+you have these roles:
+ * `roles/iam.serviceAccountCreator`
+ * `roles/resourcemanager.projectIamAdmin`
+ * `roles/apigee.apiAdminV2`
+
+...then you can use this sample, but you need to insure some other person has enabled the Cloud
+Logging API on your project. We will check that the Logging API is enabled in the next step.
+
+---
+
+## Verify that the Logging API is enabled
+
+Owners or Editors on a Google Cloud Project must enable individual services, for
+them to be available.  Let's check that the Logging API is enabled.
+
+
+```bash
+./check-required-services.sh
+```
+
+* If this indicates that the logging API is already enabled on the project, you can proceed.
+
+* If the logging API is not enabled, but you have editor or owner role (as shown in the previous
+  step), then the script you run in the next step will enable the logging API.
+
+* If the logging API is not enabled, and you do not have editor or owner role, then you need to
+  stop, and find someone who can enable that API on your GCP project, before proceeding here.
 
 ---
 
@@ -59,7 +104,13 @@ After issuing some calls, let's confirm the configured variables / values set on
 gcloud logging read "logName=projects/$PROJECT/logs/apigee"
 ```
 
-Cloud Logging is quite powerful. Few free to navigate to its UI in the GCP Console (_Logging_ Product Page in the console) and explore additional features such as filters, custom searches, custom alerts and much more.
+Cloud Logging is quite powerful. Few free to navigate to its UI in the GCP
+Console (_Logging_ Product Page in the console) and explore additional features
+such as filters, custom searches, custom alerts and much more.
+
+If you are so inclined, you can modify the apiproxy, introducing new policies,
+or modifying the existing MessageLogging policy. Re-deploy the updated version,
+and then re-run your tests, and re-examine the logs.
 
 ---
 

--- a/cloud-logging/lib/utils.sh
+++ b/cloud-logging/lib/utils.sh
@@ -14,115 +14,117 @@
 # limitations under the License.
 
 is_directory_changed() {
-    # Compute a checksum of the files inside the directory, compare it to any
-    # previous checksum, to determine if any change has been made. This can help
-    # avoid an unnecessary re-import and re-deploy, when modifying the proxy and
-    # deploying iteratively.
-    local dir_of_interest; dir_of_interest=$1
-    local parent_name; parent_name=$(dirname "${dir_of_interest}")
-    local short_name; short_name=$(basename "${dir_of_interest}")
-    local NEW_SHASUM_FILE
-    # shellcheck disable=SC2154
-    NEW_SHASUM_FILE=$(mktemp "/tmp/${scriptid}.out.XXXXXX")
-    # https://stackoverflow.com/a/5431932
-    tar -cf - --exclude='*.*~' --exclude='*~' "$dir_of_interest" | shasum >"$NEW_SHASUM_FILE"
-    local PERM_SHASUM_FILE="${parent_name}/.${short_name}.shasum"
-    if [[ -f "${PERM_SHASUM_FILE}" ]]; then
-        local current_value
-        current_value=$(<"$NEW_SHASUM_FILE")
-        current_value="${current_value//[$'\t\r\n ']/}"
-        local previous_value
-        previous_value=$(<"$PERM_SHASUM_FILE")
-        previous_value="${previous_value//[$'\t\r\n ']/}"
-        if [[ "$current_value" == "$previous_value" ]]; then
-            false
-        else
-            cp "$NEW_SHASUM_FILE" "${PERM_SHASUM_FILE}"
-            true
-        fi
+  # Compute a checksum of the files inside the directory, compare it to any
+  # previous checksum, to determine if any change has been made. This can help
+  # avoid an unnecessary re-import and re-deploy, when modifying the proxy and
+  # deploying iteratively.
+  local dir_of_interest
+  dir_of_interest=$1
+  local parent_name
+  parent_name=$(dirname "${dir_of_interest}")
+  local short_name
+  short_name=$(basename "${dir_of_interest}")
+  local NEW_SHASUM_FILE
+  # shellcheck disable=SC2154
+  NEW_SHASUM_FILE=$(mktemp "/tmp/${scriptid}.out.XXXXXX")
+  # https://stackoverflow.com/a/5431932
+  tar -cf - --exclude='*.*~' --exclude='*~' "$dir_of_interest" | shasum >"$NEW_SHASUM_FILE"
+  local PERM_SHASUM_FILE="${parent_name}/.${short_name}.shasum"
+  if [[ -f "${PERM_SHASUM_FILE}" ]]; then
+    local current_value
+    current_value=$(<"$NEW_SHASUM_FILE")
+    current_value="${current_value//[$'\t\r\n ']/}"
+    local previous_value
+    previous_value=$(<"$PERM_SHASUM_FILE")
+    previous_value="${previous_value//[$'\t\r\n ']/}"
+    if [[ "$current_value" == "$previous_value" ]]; then
+      false
     else
-        cp "$NEW_SHASUM_FILE" "${PERM_SHASUM_FILE}"
-        true
+      cp "$NEW_SHASUM_FILE" "${PERM_SHASUM_FILE}"
+      true
     fi
+  else
+    cp "$NEW_SHASUM_FILE" "${PERM_SHASUM_FILE}"
+    true
+  fi
 }
 
 maybe_import_and_deploy() {
-    local dirpath sa_email force ORG asset_type object files name sa_params
-    dirpath="$1"
-    sa_email="$2"
-    force="$3"
-    ORG="$PROJECT"
+  local dirpath sa_email force ORG asset_type object files name sa_params
+  dirpath="$1"
+  sa_email="$2"
+  force="$3"
+  ORG="$PROJECT"
 
-    [[ -z "$APIGEE_ENV" ]] && printf "missing APIGEE_ENV\n" && exit 1
-    [[ -z "$PROJECT" ]] && printf "missing PROJECT\n" && exit 1
+  [[ -z "$APIGEE_ENV" ]] && printf "missing APIGEE_ENV\n" && exit 1
+  [[ -z "$PROJECT" ]] && printf "missing PROJECT\n" && exit 1
 
-    asset_type=$(basename "$dirpath")
-    if [[ ${asset_type} = "sharedflowbundle" ]]; then
-        object="sharedflows"
+  asset_type=$(basename "$dirpath")
+  if [[ ${asset_type} = "sharedflowbundle" ]]; then
+    object="sharedflows"
+  else
+    object="apis"
+  fi
+
+  files=("${dirpath}"/*.xml)
+  if [[ ${#files[@]} -eq 1 ]]; then
+    name="${files[0]}"
+    name=$(basename "${name%.*}")
+    if [[ "$force" = "force" ]] || is_directory_changed "$dirpath"; then
+      # import only if the dir has changed
+      printf "will import a new revision of %s [%s]\n" "$asset_type" "$name"
+      apigeecli "$object" create bundle -f "$dirpath" --name "${name}" -o "$ORG" --token "$TOKEN"
+      sa_params=""
+      if [[ -n "$sa_email" ]]; then
+        sa_params="--sa ${SA_EMAIL}"
+      fi
+      # shellcheck disable=SC2086
+      apigeecli "$object" deploy --wait --name "$name" --ovr --org "$ORG" --env "$APIGEE_ENV" --token "$TOKEN" $sa_params &
+      # shellcheck disable=SC2034
+      need_wait=1
     else
-        object="apis"
+      printf "no update needed for %s [%s]\n" "$asset_type" "$name"
     fi
-
-    files=("${dirpath}"/*.xml)
-    if [[ ${#files[@]} -eq 1 ]]; then
-        name="${files[0]}"
-        name=$(basename "${name%.*}")
-        if [[ "$force" = "force" ]] || is_directory_changed "$dirpath"; then
-            # import only if the dir has changed
-            printf "will import a new revision of %s [%s]\n" "$asset_type" "$name"
-            apigeecli "$object" create bundle -f "$dirpath" --name "${name}" -o "$ORG" --token "$TOKEN"
-            sa_params=""
-            if [[ -n "$sa_email" ]]; then
-                sa_params="--sa ${SA_EMAIL}"
-            fi
-            # shellcheck disable=SC2086
-            apigeecli "$object" deploy --wait --name "$name" --ovr --org "$ORG" --env "$APIGEE_ENV" --token "$TOKEN" $sa_params &
-            # shellcheck disable=SC2034
-            need_wait=1
-        else
-            printf "no update needed for %s [%s]\n" "$asset_type" "$name"
-        fi
-    else
-        printf "could not determine name of proxy to import\n"
-    fi
+  else
+    printf "could not determine name of proxy to import\n"
+  fi
 }
 
 create_service_account_and_grant_logWriter_role() {
-    local sa_name role ROLES_OF_INTEREST
-    sa_name="$1"
-    printf "Creating API Proxy Service Account %s...\n" "$sa_name"
-    gcloud iam service-accounts create "$sa_name"
-    printf "%s\n" "$sa_name" >./.sa_name
+  local sa_name role ROLES_OF_INTEREST
+  sa_name="$1"
+  printf "Creating API Proxy Service Account %s...\n" "$sa_name"
+  gcloud iam service-accounts create "$sa_name"
+  printf "%s\n" "$sa_name" >./.sa_name
 
-    ROLES_OF_INTEREST=( "roles/logging.logWriter" )
-    for role in "${ROLES_OF_INTEREST[@]}"; do
-        printf "Granting role %s to that SA...\n" "$role"
-        # shellcheck disable=SC2034
-        SA_EMAIL="${sa_name}@${PROJECT}.iam.gserviceaccount.com"
-        gcloud projects add-iam-policy-binding "$PROJECT" \
-               --member="serviceAccount:$SA_EMAIL" \
-               --role="$role"
-    done
+  ROLES_OF_INTEREST=("roles/logging.logWriter")
+  for role in "${ROLES_OF_INTEREST[@]}"; do
+    printf "Granting role %s to that SA...\n" "$role"
+    # shellcheck disable=SC2034
+    SA_EMAIL="${sa_name}@${PROJECT}.iam.gserviceaccount.com"
+    gcloud projects add-iam-policy-binding "$PROJECT" \
+      --member="serviceAccount:$SA_EMAIL" \
+      --role="$role"
+  done
 }
 
 maybe_install_apigeecli() {
-    if [[ ! -d "$HOME/.apigeecli/bin" ]]; then
-        printf "Installing apigeecli\n"
-        curl -s https://raw.githubusercontent.com/apigee/apigeecli/main/downloadLatest.sh | bash
-    fi
-    export PATH=$PATH:$HOME/.apigeecli/bin
+  if [[ ! -d "$HOME/.apigeecli/bin" ]]; then
+    printf "Installing apigeecli\n"
+    curl -s https://raw.githubusercontent.com/apigee/apigeecli/main/downloadLatest.sh | bash
+  fi
+  export PATH=$PATH:$HOME/.apigeecli/bin
 }
 
-
 check_shell_variables() {
-    local MISSING_ENV_VARS=()
-    [[ -z "$PROJECT" ]] && MISSING_ENV_VARS+=('PROJECT')
-    [[ -z "$APIGEE_ENV" ]] && MISSING_ENV_VARS+=('APIGEE_ENV')
-    [[ -z "$APIGEE_HOST" ]] && MISSING_ENV_VARS+=('APIGEE_HOST')
+  local MISSING_ENV_VARS=()
+  [[ -z "$PROJECT" ]] && MISSING_ENV_VARS+=('PROJECT')
+  [[ -z "$APIGEE_ENV" ]] && MISSING_ENV_VARS+=('APIGEE_ENV')
+  [[ -z "$APIGEE_HOST" ]] && MISSING_ENV_VARS+=('APIGEE_HOST')
 
-    [[ ${#MISSING_ENV_VARS[@]} -ne 0 ]] && {
-        printf -v joined '%s,' "${MISSING_ENV_VARS[@]}"
-        printf "You must set these environment variables: %s\n" "${joined%,}"
-        exit 1
-    }
+  [[ ${#MISSING_ENV_VARS[@]} -ne 0 ]] && {
+    printf -v joined '%s,' "${MISSING_ENV_VARS[@]}"
+    printf "You must set these environment variables: %s\n" "${joined%,}"
+    exit 1
+  }
 }

--- a/cloud-logging/lib/utils.sh
+++ b/cloud-logging/lib/utils.sh
@@ -21,8 +21,9 @@ is_directory_changed() {
     local dir_of_interest; dir_of_interest=$1
     local parent_name; parent_name=$(dirname "${dir_of_interest}")
     local short_name; short_name=$(basename "${dir_of_interest}")
+    local NEW_SHASUM_FILE
     # shellcheck disable=SC2154
-    local NEW_SHASUM_FILE; NEW_SHASUM_FILE=$(mktemp "/tmp/${scriptid}.out.XXXXXX")
+    NEW_SHASUM_FILE=$(mktemp "/tmp/${scriptid}.out.XXXXXX")
     # https://stackoverflow.com/a/5431932
     tar -cf - --exclude='*.*~' --exclude='*~' "$dir_of_interest" | shasum >"$NEW_SHASUM_FILE"
     local PERM_SHASUM_FILE="${parent_name}/.${short_name}.shasum"

--- a/cloud-logging/lib/utils.sh
+++ b/cloud-logging/lib/utils.sh
@@ -1,0 +1,120 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+is_directory_changed() {
+    # Compute a checksum of the files inside the directory, compare it to any
+    # previous checksum, to determine if any change has been made. This can help
+    # avoid an unnecessary re-import and re-deploy, when modifying the proxy and
+    # deploying iteratively.
+    local dir_of_interest=$1
+    local parent_name=$(dirname "${dir_of_interest}")
+    local short_name=$(basename "${dir_of_interest}")
+    local NEW_SHASUM_FILE=$(mktemp /tmp/${scriptid}.out.XXXXXX)
+    # https://stackoverflow.com/a/5431932
+    tar -cf - --exclude='*.*~' --exclude='*~' $dir_of_interest | shasum >"$NEW_SHASUM_FILE"
+    local PERM_SHASUM_FILE="${parent_name}/.${short_name}.shasum"
+    if [[ -f "${PERM_SHASUM_FILE}" ]]; then
+        local current_value=$(<"$NEW_SHASUM_FILE")
+        current_value="${current_value//[$'\t\r\n ']/}"
+        local previous_value=$(<"$PERM_SHASUM_FILE")
+        previous_value="${previous_value//[$'\t\r\n ']/}"
+        if [[ "$current_value" == "$previous_value" ]]; then
+            false
+        else
+            cp "$NEW_SHASUM_FILE" "${PERM_SHASUM_FILE}"
+            true
+        fi
+    else
+        cp "$NEW_SHASUM_FILE" "${PERM_SHASUM_FILE}"
+        true
+    fi
+}
+
+maybe_import_and_deploy() {
+    local dirpath=$1
+    local sa_email=$2
+    local force="$3"
+    local ORG="$PROJECT"
+
+    [[ -z "$APIGEE_ENV" ]] && printf "missing APIGEE_ENV\n" && exit 1
+    [[ -z "$PROJECT" ]] && printf "missing PROJECT\n" && exit 1
+
+    local asset_type=$(basename $dirpath)
+    local object
+    if [[ ${asset_type} = "sharedflowbundle" ]]; then
+        object="sharedflows"
+    else
+        object="apis"
+    fi
+
+    local files=(${dirpath}/*.xml)
+    if [[ ${#files[@]} -eq 1 ]]; then
+        local name="${files[0]}"
+        name=$(basename "${name%.*}")
+        if [[ "$force" = "force" ]] || is_directory_changed $dirpath; then
+            # import only if the dir has changed
+            printf "will import a new revision of %s [%s]\n" "$asset_type" "$name"
+            apigeecli $object create bundle -f $dirpath --name "${name}" -o $ORG --token $TOKEN
+            local SA_PARAMS=""
+            if [[ ! -z "$sa_email" ]]; then
+                SA_PARAMS="--sa ${SA_EMAIL}"
+            fi
+            apigeecli $object deploy --wait --name "$name" --ovr --org $ORG --env "$APIGEE_ENV" --token $TOKEN $SA_PARAMS &
+            need_wait=1
+        else
+            printf "no update needed for %s [%s]\n" "$asset_type" "$name"
+        fi
+    else
+        printf "could not determine name of proxy to import\n"
+    fi
+}
+
+create_service_account_and_grant_logWriter_role() {
+    local sa_name="$1"
+    local role
+    printf "Creating API Proxy Service Account %s...\n" "$sa_name"
+    gcloud iam service-accounts create "$sa_name"
+    printf "%s\n" "$sa_name" >./.sa_name
+
+    local ROLES_OF_INTEREST=( "roles/logging.logWriter" )
+    for role in "${ROLES_OF_INTEREST[@]}"; do
+        printf "Granting role %s to that SA...\n" "$role"
+        SA_EMAIL="${sa_name}@${PROJECT}.iam.gserviceaccount.com"
+        gcloud projects add-iam-policy-binding "$PROJECT" \
+               --member="serviceAccount:$SA_EMAIL" \
+               --role="$role"
+    done
+}
+
+maybe_install_apigeecli() {
+    if [[ ! -d $HOME/.apigeecli/bin ]]; then
+        echo "Installing apigeecli\n"
+        curl -s https://raw.githubusercontent.com/apigee/apigeecli/main/downloadLatest.sh | bash
+    fi
+    export PATH=$PATH:$HOME/.apigeecli/bin
+}
+
+
+check_shell_variables() {
+    local MISSING_ENV_VARS=()
+    [[ -z "$PROJECT" ]] && MISSING_ENV_VARS+=('PROJECT')
+    [[ -z "$APIGEE_ENV" ]] && MISSING_ENV_VARS+=('APIGEE_ENV')
+    [[ -z "$APIGEE_HOST" ]] && MISSING_ENV_VARS+=('APIGEE_HOST')
+
+    [[ ${#MISSING_ENV_VARS[@]} -ne 0 ]] && {
+        printf -v joined '%s,' "${MISSING_ENV_VARS[@]}"
+        printf "You must set these environment variables: %s\n" "${joined%,}"
+        exit 1
+    }
+}

--- a/cloud-logging/lib/utils.sh
+++ b/cloud-logging/lib/utils.sh
@@ -21,6 +21,7 @@ is_directory_changed() {
     local dir_of_interest; dir_of_interest=$1
     local parent_name; parent_name=$(dirname "${dir_of_interest}")
     local short_name; short_name=$(basename "${dir_of_interest}")
+    # shellcheck disable=SC2154
     local NEW_SHASUM_FILE; NEW_SHASUM_FILE=$(mktemp "/tmp/${scriptid}.out.XXXXXX")
     # https://stackoverflow.com/a/5431932
     tar -cf - --exclude='*.*~' --exclude='*~' "$dir_of_interest" | shasum >"$NEW_SHASUM_FILE"
@@ -45,7 +46,7 @@ is_directory_changed() {
 }
 
 maybe_import_and_deploy() {
-    local dirpath sa_email force ORG asset_type object files name SA_PARAMS
+    local dirpath sa_email force ORG asset_type object files name sa_params
     dirpath="$1"
     sa_email="$2"
     force="$3"
@@ -61,7 +62,7 @@ maybe_import_and_deploy() {
         object="apis"
     fi
 
-    files=(${dirpath}/*.xml)
+    files=("${dirpath}"/*.xml)
     if [[ ${#files[@]} -eq 1 ]]; then
         name="${files[0]}"
         name=$(basename "${name%.*}")
@@ -70,7 +71,7 @@ maybe_import_and_deploy() {
             printf "will import a new revision of %s [%s]\n" "$asset_type" "$name"
             apigeecli "$object" create bundle -f "$dirpath" --name "${name}" -o "$ORG" --token "$TOKEN"
             sa_params=""
-            if [[ ! -z "$sa_email" ]]; then
+            if [[ -n "$sa_email" ]]; then
                 sa_params="--sa ${SA_EMAIL}"
             fi
             # shellcheck disable=SC2086

--- a/cloud-logging/redeploy-bundle.sh
+++ b/cloud-logging/redeploy-bundle.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Copyright 2023-2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SA_BASE="example-cloudlogger-sa-"
+PROXY_NAME="sample-cloud-logging"
+scriptid="redeploy-bundle"
+
+source ./lib/utils.sh
+
+# ====================================================================
+
+MISSING_ENV_VARS=()
+[[ -z "$PROJECT" ]] && MISSING_ENV_VARS+=('PROJECT')
+[[ -z "$APIGEE_ENV" ]] && MISSING_ENV_VARS+=('APIGEE_ENV')
+[[ -z "$APIGEE_HOST" ]] && MISSING_ENV_VARS+=('APIGEE_HOST')
+
+[[ ${#MISSING_ENV_VARS[@]} -ne 0 ]] && {
+    printf -v joined '%s,' "${MISSING_ENV_VARS[@]}"
+    printf "You must set these environment variables: %s\n" "${joined%,}"
+    exit 1
+}
+
+TOKEN=$(gcloud auth print-access-token)
+
+maybe_install_apigeecli
+
+SA_NAME=$(<./.sa_name)
+need_sa=0
+if [[ -z "$SA_NAME" ]]; then
+    need_sa=1
+else
+    SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+    if gcloud iam service-accounts describe "$SA_EMAIL" > /dev/null ; then
+        printf "Found existing SA [%s]\n" "$SA_EMAIL"
+    else
+        need_sa=1
+    fi
+fi
+
+if [[ $need_sa -eq 1 ]]; then
+    rand_string=$(cat /dev/urandom | LC_CTYPE=C tr -cd '[:alnum:]' | head -c 6)
+    SA_NAME="${SA_BASE}${rand_string}"
+    create_service_account_and_grant_logWriter_role "$SA_NAME"
+    # the above implicitly sets SA_EMAIL
+fi
+
+printf "Checking if proxy needs to be redeployed...\n"
+maybe_import_and_deploy ./apiproxy "$SA_EMAIL"
+
+# wait outside of the fn, in case there were multiple deploys
+if [[ $need_wait -eq 1 ]]; then
+    printf "Waiting...\n"
+    wait
+    printf "redeployed...\n"
+else
+    printf "redeploy was not necessary...\n"
+fi

--- a/cloud-logging/redeploy-bundle.sh
+++ b/cloud-logging/redeploy-bundle.sh
@@ -35,6 +35,7 @@ MISSING_ENV_VARS=()
     exit 1
 }
 
+# shellcheck disable=SC2034
 TOKEN=$(gcloud auth print-access-token)
 
 maybe_install_apigeecli

--- a/cloud-logging/redeploy-bundle.sh
+++ b/cloud-logging/redeploy-bundle.sh
@@ -15,7 +15,9 @@
 # limitations under the License.
 
 SA_BASE="example-cloudlogger-sa-"
+# shellcheck disable=SC2034
 PROXY_NAME="sample-cloud-logging"
+# shellcheck disable=SC2034
 scriptid="redeploy-bundle"
 
 source ./lib/utils.sh
@@ -37,6 +39,7 @@ TOKEN=$(gcloud auth print-access-token)
 
 maybe_install_apigeecli
 
+# shellcheck disable=SC2034
 SA_NAME=$(<./.sa_name)
 need_sa=0
 if [[ -z "$SA_NAME" ]]; then
@@ -51,6 +54,7 @@ else
 fi
 
 if [[ $need_sa -eq 1 ]]; then
+    # shellcheck disable=SC2002
     rand_string=$(cat /dev/urandom | LC_CTYPE=C tr -cd '[:alnum:]' | head -c 6)
     SA_NAME="${SA_BASE}${rand_string}"
     create_service_account_and_grant_logWriter_role "$SA_NAME"
@@ -61,6 +65,7 @@ printf "Checking if proxy needs to be redeployed...\n"
 maybe_import_and_deploy ./apiproxy "$SA_EMAIL"
 
 # wait outside of the fn, in case there were multiple deploys
+# shellcheck disable=SC2154
 if [[ $need_wait -eq 1 ]]; then
     printf "Waiting...\n"
     wait

--- a/cloud-logging/redeploy-bundle.sh
+++ b/cloud-logging/redeploy-bundle.sh
@@ -30,9 +30,9 @@ MISSING_ENV_VARS=()
 [[ -z "$APIGEE_HOST" ]] && MISSING_ENV_VARS+=('APIGEE_HOST')
 
 [[ ${#MISSING_ENV_VARS[@]} -ne 0 ]] && {
-    printf -v joined '%s,' "${MISSING_ENV_VARS[@]}"
-    printf "You must set these environment variables: %s\n" "${joined%,}"
-    exit 1
+  printf -v joined '%s,' "${MISSING_ENV_VARS[@]}"
+  printf "You must set these environment variables: %s\n" "${joined%,}"
+  exit 1
 }
 
 # shellcheck disable=SC2034
@@ -44,22 +44,22 @@ maybe_install_apigeecli
 SA_NAME=$(<./.sa_name)
 need_sa=0
 if [[ -z "$SA_NAME" ]]; then
-    need_sa=1
+  need_sa=1
 else
-    SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
-    if gcloud iam service-accounts describe "$SA_EMAIL" > /dev/null ; then
-        printf "Found existing SA [%s]\n" "$SA_EMAIL"
-    else
-        need_sa=1
-    fi
+  SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+  if gcloud iam service-accounts describe "$SA_EMAIL" >/dev/null; then
+    printf "Found existing SA [%s]\n" "$SA_EMAIL"
+  else
+    need_sa=1
+  fi
 fi
 
 if [[ $need_sa -eq 1 ]]; then
-    # shellcheck disable=SC2002
-    rand_string=$(cat /dev/urandom | LC_CTYPE=C tr -cd '[:alnum:]' | head -c 6)
-    SA_NAME="${SA_BASE}${rand_string}"
-    create_service_account_and_grant_logWriter_role "$SA_NAME"
-    # the above implicitly sets SA_EMAIL
+  # shellcheck disable=SC2002
+  rand_string=$(cat /dev/urandom | LC_CTYPE=C tr -cd '[:alnum:]' | head -c 6)
+  SA_NAME="${SA_BASE}${rand_string}"
+  create_service_account_and_grant_logWriter_role "$SA_NAME"
+  # the above implicitly sets SA_EMAIL
 fi
 
 printf "Checking if proxy needs to be redeployed...\n"
@@ -68,9 +68,9 @@ maybe_import_and_deploy ./apiproxy "$SA_EMAIL"
 # wait outside of the fn, in case there were multiple deploys
 # shellcheck disable=SC2154
 if [[ $need_wait -eq 1 ]]; then
-    printf "Waiting...\n"
-    wait
-    printf "redeployed...\n"
+  printf "Waiting...\n"
+  wait
+  printf "redeployed...\n"
 else
-    printf "redeploy was not necessary...\n"
+  printf "redeploy was not necessary...\n"
 fi


### PR DESCRIPTION
One customer said the cloud-logging sample was not working. I suspect this is because the logging API was not enabled, and the user did not have the correct permissions to enable it.  This change addresses those possibilities.

- Expanded the README a little, to explain and guide through checking service enablement, and roles

- Enhanced the deploy script, to check whether the logging API is enabled, and to check whether enabling it is successful.

- Enhanced the cleanup script
- added two other check scripts
- factored some common logic out into a utils module

