### PR TITLE
fix: grpc proto issues and deprecated apigeecli flags

### DIFF
--- a/grpc/Dockerfile
+++ b/grpc/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 
 COPY grpc-backend/examples/python/helloworld .
 
-RUN pip install --upgrade grpcio protobuf
+RUN pip install --no-cache-dir grpcio==1.70.0 protobuf==5.29.3
 
 EXPOSE 50051
 

--- a/grpc/Dockerfile
+++ b/grpc/Dockerfile
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.7
+FROM python:3.8
 
 WORKDIR /app
 
 COPY grpc-backend/examples/python/helloworld .
 
-RUN pip install --no-cache-dir grpcio==1.58.0 protobuf==4.24.3
+RUN pip install --upgrade grpcio protobuf
 
 EXPOSE 50051
 

--- a/grpc/deploy.sh
+++ b/grpc/deploy.sh
@@ -54,7 +54,7 @@ ENVIRONMENT_GROUP_NAME="sample-environment-group"
 
 # Create and attach a sample Apigee environment
 echo -n "Creating environment..."
-apigeecli environments create -o "$PROJECT" -e "$ENVIRONMENT_NAME" -d PROXY -p PROGRAMMABLE --wait=true -t "$TOKEN"
+apigeecli environments create -o "$PROJECT" -e "$ENVIRONMENT_NAME" -d PROXY --wait=true -t "$TOKEN"
 
 
 echo -n "Attaching environment to instance (may take a few minutes)..."


### PR DESCRIPTION
Fixed some issues with the grpc sample with the python and protobuf versions and removed a deprecated option from the apigeecli command to create an environment