### PR TITLE
fix: changing list flow condition to return multiple elements to agent

### DIFF
--- a/adk-cymbal-retail-agent/proxies/cymbal-customers-v1/apiproxy/proxies/default.xml
+++ b/adk-cymbal-retail-agent/proxies/cymbal-customers-v1/apiproxy/proxies/default.xml
@@ -38,7 +38,7 @@
         </Step>
       </Request>
       <Response/>
-      <Condition>(proxy.pathsuffix MatchesPath "/") and (request.verb = "GET")</Condition>
+      <Condition>((request.path MatchesPath "/v1/samples/adk-cymbal-retail/customers" or request.path MatchesPath "/v1/samples/adk-cymbal-retail/customers/")) and (request.verb = "GET")</Condition>
     </Flow>
     <Flow name="createCustomer">
       <Description>Creates a new customer.</Description>

--- a/adk-cymbal-retail-agent/proxies/cymbal-orders-v1/apiproxy/proxies/default.xml
+++ b/adk-cymbal-retail-agent/proxies/cymbal-orders-v1/apiproxy/proxies/default.xml
@@ -38,7 +38,7 @@
         </Step>
       </Request>
       <Response/>
-      <Condition>(proxy.pathsuffix MatchesPath "/") and (request.verb = "GET")</Condition>
+      <Condition>((request.path MatchesPath "/v1/samples/adk-cymbal-retail/orders" or request.path MatchesPath "/v1/samples/adk-cymbal-retail/orders/")) and (request.verb = "GET")</Condition>
     </Flow>
     <Flow name="createOrder">
       <Description>Creates a new order.</Description>

--- a/adk-cymbal-retail-agent/proxies/cymbal-returns-v1/apiproxy/proxies/default.xml
+++ b/adk-cymbal-retail-agent/proxies/cymbal-returns-v1/apiproxy/proxies/default.xml
@@ -38,7 +38,7 @@
         </Step>
       </Request>
       <Response/>
-      <Condition>(proxy.pathsuffix MatchesPath "/") and (request.verb = "GET")</Condition>
+      <Condition>((request.path MatchesPath "/v1/samples/adk-cymbal-retail/returns" or request.path MatchesPath "/v1/samples/adk-cymbal-retail/returns/")) and (request.verb = "GET")</Condition>
     </Flow>
     <Flow name="createReturn">
       <Description>Creates a new return.</Description>


### PR DESCRIPTION
Currently listOrders, listCustomers and listReturns are not being invoked by the agent when they should, as the getOrder, getCustomers, getReturns flows are being invoked instead and returning single items due to conditional logic as configured.

Updated the relevant <Condition> element of each proxy to fix this.