### PR TITLE
fix: minor proso(typo) in deploy script for llm-routing

### DIFF
--- a/llm-routing/deploy-llm-routing.sh
+++ b/llm-routing/deploy-llm-routing.sh
@@ -176,7 +176,7 @@ echo "  --data '{
   \"stream\": false
 }'"
 echo " "
-echo "Export these variables"
+echo "Export this variable"
 echo "  export APIKEY=$APIKEY"
 echo " "
 echo "You can now go back to the Colab notebook to test the sample. You will need the following variables during your test."


### PR DESCRIPTION
No functional change, just a change in the message emitted by the script.