### PR TITLE
fix: suppress TD002 apigeelint warnings with disable directives

### DIFF
--- a/adk-auto-insurance-agent/apiproxy/targets/default.xml
+++ b/adk-auto-insurance-agent/apiproxy/targets/default.xml
@@ -40,6 +40,7 @@
       </GoogleAccessToken>
     </Authentication>
     <Properties/>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://{propertyset.vertex_config.region}-aiplatform.googleapis.com/v1/projects/{propertyset.vertex_config.project_id}/locations/{propertyset.vertex_config.region}/publishers/google/models/{propertyset.vertex_config.model_id}:generateContent</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/apigee-mcp/apigee_resources/bundles/crm-mcp-proxy/apiproxy/targets/default.xml
+++ b/apigee-mcp/apigee_resources/bundles/crm-mcp-proxy/apiproxy/targets/default.xml
@@ -29,6 +29,7 @@ limitations under the License.
         <Audience>https://TARGETURL</Audience>
       </GoogleIDToken>
     </Authentication>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://TARGETURL/crm-mcp-proxy</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/apigee-mcp/apigee_resources/bundles/customers-api/apiproxy/targets/default.xml
+++ b/apigee-mcp/apigee_resources/bundles/customers-api/apiproxy/targets/default.xml
@@ -25,6 +25,7 @@ limitations under the License.
         <Audience>https://TARGETURL</Audience>
       </GoogleIDToken>
     </Authentication>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://TARGETURL</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/apigee-mcp/apigee_resources/bundles/mcp-spec-tools/apiproxy/targets/default.xml
+++ b/apigee-mcp/apigee_resources/bundles/mcp-spec-tools/apiproxy/targets/default.xml
@@ -44,6 +44,7 @@ limitations under the License.
         </Scopes>
       </GoogleAccessToken>
     </Authentication>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://apihub.googleapis.com/v1/projects/{project_id}/locations/{location_id}/apis/{api_id}/versions/{version_id}/specs/{spec_id}:contents</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/authorize-idp-access-tokens/apiproxy/targets/default.xml
+++ b/authorize-idp-access-tokens/apiproxy/targets/default.xml
@@ -26,6 +26,7 @@ limitations under the License.
         <Response/>
     </PostFlow>
     <HTTPTargetConnection>
+        <!-- apigeelint disable=TD002 -->
         <URL>https://httpbin.org/get</URL>
     </HTTPTargetConnection>
 </TargetEndpoint>

--- a/basic-caching/apiproxy/targets/default.xml
+++ b/basic-caching/apiproxy/targets/default.xml
@@ -34,6 +34,7 @@
     </Response>
   </PostFlow>
   <HTTPTargetConnection>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://www.googleapis.com/books/v1/volumes</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/cloud-functions/bundle/cloud-function-http-trigger/apiproxy/targets/target-1.xml
+++ b/cloud-functions/bundle/cloud-function-http-trigger/apiproxy/targets/target-1.xml
@@ -53,6 +53,7 @@
     </SSLInfo>
 
     <!-- the proxy.pathsuffix will get appended to this -->
+    <!-- apigeelint disable=TD002 -->
     <URL>https://THIS-URL-WILL-BE-REPLACED.a.run.app/apigee-sample-hello</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/cloud-logging/apiproxy/targets/default.xml
+++ b/cloud-logging/apiproxy/targets/default.xml
@@ -22,6 +22,7 @@
     <Response/>
   </PostFlow>
   <HTTPTargetConnection>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://httpbin.org/get</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/cloud-run/apiproxy/targets/default.xml
+++ b/cloud-run/apiproxy/targets/default.xml
@@ -30,6 +30,7 @@
                 <Audience>@TARGETURL@</Audience>
             </GoogleIDToken>
         </Authentication>
+        <!-- apigeelint disable=TD002 -->
         <URL>@TARGETURL@</URL>
     </HTTPTargetConnection>
 </TargetEndpoint>

--- a/composite-api/apiproxy/targets/default.xml
+++ b/composite-api/apiproxy/targets/default.xml
@@ -29,6 +29,7 @@
     <Flows/>
     <HTTPTargetConnection>
         <Properties/>
+        <!-- apigeelint disable=TD002 -->
         <URL>https://api.open-meteo.com/v1/forecast</URL>
     </HTTPTargetConnection>
 </TargetEndpoint>

--- a/deploy-apigee-proxy/apiproxy/targets/default.xml
+++ b/deploy-apigee-proxy/apiproxy/targets/default.xml
@@ -22,6 +22,7 @@
     <Response/>
   </PostFlow>
   <HTTPTargetConnection>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://httpbin.org/get</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/drupal-developer-portal/apiproxy/targets/default.xml
+++ b/drupal-developer-portal/apiproxy/targets/default.xml
@@ -22,6 +22,7 @@
     <Response/>
   </PostFlow>
   <HTTPTargetConnection>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://httpbin.org/anything</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/extract-variables/apiproxy/targets/default.xml
+++ b/extract-variables/apiproxy/targets/default.xml
@@ -26,6 +26,7 @@
     <Response/>
   </PostFlow>
   <HTTPTargetConnection>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://mocktarget.apigee.net/xml</URL>
     <SSLInfo>
       <Enabled>true</Enabled>

--- a/grpc-web/bundle/apiproxy/targets/default.xml
+++ b/grpc-web/bundle/apiproxy/targets/default.xml
@@ -22,6 +22,7 @@
         <Response/>
     </PostFlow>
     <HTTPTargetConnection>
+        <!-- apigeelint disable=TD002 -->
         <URL>@TARGETURL@</URL>
     </HTTPTargetConnection>
 </TargetEndpoint>

--- a/integrated-developer-portal/apiproxy/targets/default.xml
+++ b/integrated-developer-portal/apiproxy/targets/default.xml
@@ -22,6 +22,7 @@
     <Response/>
   </PostFlow>
   <HTTPTargetConnection>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://httpbin.org/anything</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/llm-circuit-breaking/apiproxy/targets/primary.xml
+++ b/llm-circuit-breaking/apiproxy/targets/primary.xml
@@ -51,6 +51,7 @@
     <Properties>
       <Property name="request.streaming.enabled">true</Property>
     </Properties>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://{propertyset.vertex_config.region_p1}-aiplatform.googleapis.com/v1/projects/{propertyset.vertex_config.project_p1}/locations/{propertyset.vertex_config.region_p1}/publishers/google/models/{request_model_id}</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/llm-circuit-breaking/apiproxy/targets/secondary.xml
+++ b/llm-circuit-breaking/apiproxy/targets/secondary.xml
@@ -35,6 +35,7 @@
     <Properties>
       <Property name="request.streaming.enabled">true</Property>
     </Properties>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://{propertyset.vertex_config.region_p2}-aiplatform.googleapis.com/v1/projects/{propertyset.vertex_config.project_p2}/locations/{propertyset.vertex_config.region_p2}/publishers/google/models/{request_model_id}</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/llm-logging/apiproxy/targets/primary.xml
+++ b/llm-logging/apiproxy/targets/primary.xml
@@ -37,6 +37,7 @@
   </PostFlow>
   <Flows/>
   <HTTPTargetConnection>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://{propertyset.vertex_config.region_p1}-aiplatform.googleapis.com/v1/projects/{propertyset.vertex_config.project_p1}/locations/{propertyset.vertex_config.region_p1}/publishers/google/models/{request_model_id}</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/llm-routing/proxybundles/llm-routing-v1/apiproxy/targets/google.xml
+++ b/llm-routing/proxybundles/llm-routing-v1/apiproxy/targets/google.xml
@@ -31,6 +31,7 @@
     </Authentication>
     <Properties/>
     <!-- The URL will be dynamically set via the target.url variable -->
+    <!-- apigeelint disable=TD002 -->
     <URL>https://notused.com</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/llm-routing/proxybundles/llm-routing-v1/apiproxy/targets/others.xml
+++ b/llm-routing/proxybundles/llm-routing-v1/apiproxy/targets/others.xml
@@ -29,6 +29,7 @@
     <HTTPTargetConnection>
       <Properties/>
       <!-- The URL will be dynamically set via the target.url variable -->
+      <!-- apigeelint disable=TD002 -->
       <URL>https://notused.com</URL>
     </HTTPTargetConnection>
 </TargetEndpoint>

--- a/llm-security-v2/proxybundles/llm-security-v2/apiproxy/targets/llm.xml
+++ b/llm-security-v2/proxybundles/llm-security-v2/apiproxy/targets/llm.xml
@@ -35,6 +35,7 @@
             </GoogleAccessToken>
         </Authentication>
         <Properties/>
+        <!-- apigeelint disable=TD002 -->
         <URL>https://{target.url}</URL>
     </HTTPTargetConnection>
 </TargetEndpoint>

--- a/llm-security/proxybundles/llm-security-v1/apiproxy/targets/llm.xml
+++ b/llm-security/proxybundles/llm-security-v1/apiproxy/targets/llm.xml
@@ -35,6 +35,7 @@
             </GoogleAccessToken>
         </Authentication>
         <Properties/>
+        <!-- apigeelint disable=TD002 -->
         <URL>https://{target.url}</URL>
     </HTTPTargetConnection>
 </TargetEndpoint>

--- a/llm-semantic-cache-v2/apiproxy/targets/default.xml
+++ b/llm-semantic-cache-v2/apiproxy/targets/default.xml
@@ -27,6 +27,7 @@
   </PostFlow>
   <HTTPTargetConnection>
     <Properties/>
+  <!-- apigeelint disable=TD002 -->
   <URL>https://REGION-aiplatform.googleapis.com</URL>
 </HTTPTargetConnection>
 </TargetEndpoint>

--- a/llm-semantic-cache/apiproxy/targets/default.xml
+++ b/llm-semantic-cache/apiproxy/targets/default.xml
@@ -25,6 +25,7 @@
     <Properties>
       <Property name="request.streaming.enabled">true</Property>
     </Properties>
+  <!-- apigeelint disable=TD002 -->
   <URL>https://{propertyset.vertex_config.region}-aiplatform.googleapis.com</URL>
 </HTTPTargetConnection>
 </TargetEndpoint>

--- a/llm-sse-logging/apiproxy/targets/default.xml
+++ b/llm-sse-logging/apiproxy/targets/default.xml
@@ -43,6 +43,7 @@
       </GoogleAccessToken>
     </Authentication>
     <Properties/>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://{region}-aiplatform.googleapis.com</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/llm-sse-security/apiproxy/targets/default.xml
+++ b/llm-sse-security/apiproxy/targets/default.xml
@@ -48,6 +48,7 @@
       </GoogleAccessToken>
     </Authentication>
     <Properties/>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://{region}-aiplatform.googleapis.com</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/llm-token-limits-per-user/apiproxy/targets/default.xml
+++ b/llm-token-limits-per-user/apiproxy/targets/default.xml
@@ -43,6 +43,7 @@
     <Properties>
       <Property name="request.streaming.enabled">true</Property>
     </Properties>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://{propertyset.vertex_config.region}-aiplatform.googleapis.com</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/llm-token-limits/apiproxy/targets/default.xml
+++ b/llm-token-limits/apiproxy/targets/default.xml
@@ -43,6 +43,7 @@
     <Properties>
       <Property name="request.streaming.enabled">true</Property>
     </Properties>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://{propertyset.vertex_config.region}-aiplatform.googleapis.com</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/monolith-to-microservices-based-on-paths/apiproxy/targets/Microservice.xml
+++ b/monolith-to-microservices-based-on-paths/apiproxy/targets/Microservice.xml
@@ -27,6 +27,7 @@
     <Response />
   </PostFlow>
   <HTTPTargetConnection>
+    <!-- apigeelint disable=TD002 -->
     <URL>MICROSERVICE_PATH</URL>
     <Properties />
   </HTTPTargetConnection>

--- a/monolith-to-microservices-based-on-paths/apiproxy/targets/Monolith.xml
+++ b/monolith-to-microservices-based-on-paths/apiproxy/targets/Monolith.xml
@@ -29,6 +29,7 @@
   <Flows />
   <HTTPTargetConnection>
     <Properties />
+    <!-- apigeelint disable=TD002 -->
     <URL>LEGACY_PATH</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/threat-protection/apiproxy/targets/default.xml
+++ b/threat-protection/apiproxy/targets/default.xml
@@ -22,6 +22,7 @@
     <Response/>
   </PostFlow>
   <HTTPTargetConnection>
+    <!-- apigeelint disable=TD002 -->
     <URL>https://mocktarget.apigee.net/</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/traffic-mirroring-sharedflow/example-proxy/apiproxy/targets/default.xml
+++ b/traffic-mirroring-sharedflow/example-proxy/apiproxy/targets/default.xml
@@ -23,6 +23,7 @@
         <Response/>
     </PostFlow>
     <HTTPTargetConnection>
+        <!-- apigeelint disable=TD002 -->
         <URL>https://httpbin.org</URL>
     </HTTPTargetConnection>
 </TargetEndpoint>


### PR DESCRIPTION
### 🤔 About This Approach

This PR suppresses 32 TD002 warnings using `<!-- apigeelint disable=TD002 -->` comments instead of refactoring to Target Servers.

**Feel free to close this PR** if you prefer:
- To keep warnings visible as reminders
- To refactor to Target Servers instead
- A different approach altogether

### Why Suppress Instead of Refactor?

1. **Educational samples** - Many proxies intentionally use hardcoded URLs for clarity
2. **Already dynamic** - Most URLs use variables, propertysets, or placeholders
3. **No breaking changes** - Only adds comments, preserves all functionality
4. **Cleaner lint output** - Makes it easier to spot real issues

### Summary

- ✅ **32 files fixed** across 5 categories
- ✅ **Zero functional changes** - comments only
- ✅ **Fully documented** - see [TD002_FIXES_DOCUMENTATION.md](./TD002_FIXES_DOCUMENTATION.md)

### Categories:
1. **PropertySet variables** (11 files) - Already dynamic via configuration
2. **Dynamic target.url** (2 files) - Set at runtime by policies
3. **Deployment placeholders** (7 files) - Replaced by CI/CD scripts
4. **Placeholder with target.url** (2 files) - Dynamically overridden
5. **Educational examples** (10 files) - Intentional hardcoded URLs for demos

### Validation

```bash
./tools/pipeline-linter/check-apigeelint.sh 2>&1 | grep "TD002"
# Should return no results for these files