### PR TITLE
feat: add Azure APIM real-time on-ramp plugin for API hub

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -92,6 +92,7 @@
     "Dtoken",
     "Dusername",
     "elif",
+    "Entra",
     "entrypoint",
     "envgroup",
     "envgroups",

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Plugins, also known as *on-ramp plugins*, enable API hub to connect and ingest A
 |     | Sample                   | Description                                                                                                                                                                                                                                                 | 
 | --- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | [azure-apim](./apihub-plugins/azure-apim) | This sample provides an Application Integration template and scripts to synchronize API metadata from Azure API Management (APIM) to Apigee API hub |
+| 2   | [azure-apim-onramp-realtime](./apihub-plugins/azure-apim-onramp-realtime) | This sample provides an event-driven Azure Function that pushes Azure API Management (APIM) API create/update/delete events to Apigee API hub in near real time, using keyless Workload Identity Federation |
 
 ## <a name="modifying"></a>Modifying a sample proxy
 

--- a/apihub-plugins/azure-apim-onramp-realtime/.eslintrc.yml
+++ b/apihub-plugins/azure-apim-onramp-realtime/.eslintrc.yml
@@ -1,0 +1,19 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The on-ramp function uses modern JavaScript (optional chaining, object spread,
+# optional catch binding). Raise the parser version for this plugin only; the
+# repo root config pins ecmaVersion to 8 for legacy Apigee JS callouts.
+parserOptions:
+  ecmaVersion: 2022

--- a/apihub-plugins/azure-apim-onramp-realtime/.gitignore
+++ b/apihub-plugins/azure-apim-onramp-realtime/.gitignore
@@ -1,0 +1,3 @@
+generated.env
+node_modules/
+local.settings.json

--- a/apihub-plugins/azure-apim-onramp-realtime/README.md
+++ b/apihub-plugins/azure-apim-onramp-realtime/README.md
@@ -1,0 +1,161 @@
+# Azure API Management to Google Cloud API Hub — Real-Time On-Ramp
+
+This sample keeps Google Cloud API Hub **continuously in sync** with an Azure API Management (APIM) instance. Whenever an API is created, updated, or deleted in APIM, an Event Grid event triggers an Azure Function that pushes the change to API Hub in near real time.
+
+It is the **event-driven counterpart** to the batch [`azure-apim`](../azure-apim) plugin (which syncs on a schedule via Application Integration). Pick this one when you need low-latency sync and prefer a **keyless** trust model.
+
+## How it works
+
+```text
+APIM  (API created/updated/deleted)
+   │  emits event
+   ▼
+Azure Event Grid ──► Azure Function (onrampApimSync)
+                        │  authenticates with Workload Identity Federation
+                        │  (no client secret / no stored key)
+                        ▼
+                 Google Cloud API Hub  (plugin instance updated)
+```
+
+- **Trigger:** Event Grid subscription on the APIM service for `Microsoft.ApiManagement.API{Created,Updated,Deleted}`.
+- **Compute:** a small Azure Function App (Node.js) running `onrampApimSync`.
+- **Auth to Google:** **Workload Identity Federation (WIF)** — the Function's Azure managed identity is federated to a GCP Workload Identity Pool, so **no long-lived secret is stored** (a key difference from the batch plugin, which uses a client secret).
+
+## Where to run this
+
+This plugin spans **two clouds**. `azure_setup.sh` needs `az`, `func`, and `bicep`; `gcp_setup.sh` needs `gcloud`. No single shell ships both toolchains by default, so pick **one** of the three ways below.
+
+| Tool | Used by | Azure Cloud Shell | Google Cloud Shell | Local terminal |
+| --- | --- | :---: | :---: | :---: |
+| `az`, `func`, `bicep` | `azure_setup.sh` | native | install | install |
+| `gcloud` | `gcp_setup.sh` | install | native + pre-authenticated | install |
+
+### Option 1 — Azure Cloud Shell for everything (Recommended)
+
+Run **both** scripts from Azure Cloud Shell. `az`/`func`/`bicep` are native; you install `gcloud` once and it persists. Attach a storage account to Azure Cloud Shell first so `$HOME` (the cloned repo and the gcloud install) persists, then:
+
+```bash
+curl https://sdk.cloud.google.com > /tmp/install_gcloud.sh
+bash /tmp/install_gcloud.sh --disable-prompts --install-dir="$HOME"
+source "$HOME/google-cloud-sdk/path.bash.inc"
+gcloud auth login --no-launch-browser
+gcloud config set project <GCP_PROJECT_ID>
+```
+
+In a later session, if `gcloud` isn't found, re-run the `source` line above.
+
+### Option 2 — Azure Cloud Shell (Azure side) + Google Cloud Shell (GCP side)
+
+No installs anywhere — each shell already has its own toolchain. Run `azure_setup.sh` in Azure Cloud Shell and `gcp_setup.sh` in Google Cloud Shell (`gcloud` is native and pre-authenticated there). Copy the generated `generated.env` into the plugin folder in Google Cloud Shell before running `gcp_setup.sh`.
+
+### Option 3 — Fully local terminal
+
+Install the whole toolchain (`az`, `func`, `bicep`, `node`, `gcloud`, `jq`, `bash`), then `az login` and `gcloud auth login`, and follow the Setup steps below.
+
+## Prerequisites
+
+1. **Azure**
+    - An Azure Subscription with an **existing APIM instance**.
+    - **Entra (app registration):** creating an App Registration works **by default** (the tenant setting *"Users can register applications"* is `Yes` out of the box). You only need to act if your tenant has **disabled** it: ask an admin to re-enable it, grant your account the **Application Developer** role, or have an admin create the app and set `APP_ID` in `env.sh`. `azure_setup.sh` pre-checks this and exits early with a clear message and the `APP_ID` fallback.
+    - **Subscription/RG level:** `Owner` or `Contributor` on the resource group (to deploy resources), plus `Owner` or `User Access Administrator` to assign the APIM `Reader` role, and `Contributor` on the APIM (to enable its managed identity).
+    - **Region note:** some subscriptions have an Azure Policy that restricts regions. This sample deploys its resources into the **same region as your APIM instance** to avoid `RequestDisallowedByAzure` errors.
+2. **Google Cloud**
+    - A project with **API Hub provisioned** ([guide](https://cloud.google.com/apigee/docs/apihub/provision)) and an existing **`system-azure-apim` plugin instance** — its id goes in `env.sh` as `INSTANCE_ID`.
+    - `gcloud` authenticated to that project.
+    - Roles for the user running `gcp_setup.sh`:
+        - `roles/apihub.admin`
+        - `roles/iam.workloadIdentityPoolAdmin` (to create the WIF pool/provider)
+        - `roles/iam.serviceAccountAdmin` and `roles/resourcemanager.projectIamAdmin` (or `roles/owner`)
+    - APIs enabled (the setup script does this for you): `apihub.googleapis.com`, `iamcredentials.googleapis.com`, `sts.googleapis.com`.
+3. **Tools:** `az`, `func` (Azure Functions Core Tools), `bicep`, `gcloud`, `jq`, `node`, `bash`. How you obtain these depends on the option you pick in [Where to run this](#where-to-run-this).
+
+## Setup Instructions
+
+All the fiddly parts (App Registration, region selection, function runtime, enabling the APIM managed identity, and Event Grid ordering) are handled **inside the scripts** — you just run them in order.
+
+**Navigation:** you `cd` into the plugin folder **once** (Step 1). Every command after that is run **from that folder**. `source env.sh` only affects the shell it runs in — if you open a new Cloud Shell tab, `cd` back and `source env.sh` again first.
+
+### Step 1 — Prepare your environment and get the files
+
+Set up your shell using **one** of the three options in [Where to run this](#where-to-run-this), then clone the repo and change into the plugin folder:
+
+```bash
+git clone https://github.com/<your-fork>/apigee-samples.git
+cd apigee-samples/apihub-plugins/azure-apim-onramp-realtime
+```
+
+### Step 2 — Authenticate to both clouds
+
+```bash
+az account set --subscription <AZURE_SUBSCRIPTION_ID>
+gcloud config set project <GCP_PROJECT_ID>
+```
+
+### Step 3 — Configure your values
+
+Edit `env.sh` and fill in every `<PLACEHOLDER>` (Azure resource group + APIM name + subscription; GCP project + project number + API Hub location + plugin instance id + host):
+
+```bash
+code env.sh      # or: vi env.sh
+```
+
+### Step 4 — Load the values
+
+```bash
+source env.sh
+```
+
+### Step 5 — Configure Azure & deploy (run this BEFORE the GCP step)
+
+Creates the App Registration, deploys the Bicep template (Function App + storage + plan + managed identity + the APIM `Reader` role, plus optional Application Insights), publishes the `onrampApimSync` function, enables the APIM system-assigned managed identity, and creates the Event Grid subscription:
+
+```bash
+./azure_setup.sh
+```
+
+When it finishes it **automatically writes the three values the GCP step needs** (`AZURE_TENANT_ID`, `AZURE_APP_ID`, `AZURE_MI_OBJECT_ID`) to a generated file `generated.env`. To collect function logs, set `export ENABLE_APP_INSIGHTS=true` in `env.sh` before running (Application Insights is off by default).
+
+### Step 6 — Configure Google Cloud
+
+Auto-loads `generated.env` from the previous step, then creates the service account (one per project) with `roles/apihub.editor`, plus the Workload Identity Pool + provider (issuer = tenant, audience = app id), binds the managed identity subject to the service account, enables APIs, and reuses your API Hub plugin instance:
+
+```bash
+./gcp_setup.sh
+```
+
+When it finishes, the on-ramp is live — no further action is needed. The scripts are idempotent: re-running reuses existing resources.
+
+**Two-shell users:** copy the generated `generated.env` into the plugin folder in Google Cloud Shell before running `gcp_setup.sh`.
+
+## Verify
+
+1. In the Azure Portal, create or edit any API in your APIM instance.
+2. Within a few seconds the change appears in your API Hub plugin instance.
+3. To watch function execution, use the Azure Portal **Log stream** or Application Insights for the Function App (Application Insights is optional — enable it with `ENABLE_APP_INSIGHTS=true`; `az webapp log tail` is not supported on Linux Consumption Function Apps).
+
+## Cleanup
+
+To remove everything the sample created (or run `./cleanup.sh`):
+
+- Delete the Event Grid subscription on the APIM service.
+- Delete the Function App, App Service plan, storage account, user-assigned identity, and optional Application Insights created by the Bicep deployment.
+- Delete the App Registration / Service Principal.
+- Delete the Workload Identity Pool/provider and service account in Google Cloud.
+
+## Files Included
+
+- `README.md` — this file.
+- `env.sh` — environment variables you edit before running the scripts.
+- `gcp_setup.sh` — creates the service account (+ `apihub.editor`), the WIF pool/provider and impersonation binding, and enables the required Google Cloud APIs.
+- `azure_setup.sh` — creates the App Registration, deploys the Bicep template, publishes the function, enables the APIM managed identity, and creates the Event Grid subscription.
+- `cleanup.sh` — removes the resources the sample created.
+- `main.bicep` — infrastructure: user-assigned identity, storage account, App Service plan, Function App, optional Application Insights, and the APIM `Reader` role assignment.
+- `src/functions/onrampApimSync.js` — the Event Grid–triggered sync function.
+- `host.json`, `package.json` — Azure Functions runtime configuration.
+- `.gitignore` — excludes `generated.env`, `node_modules/`, and `local.settings.json` from commits.
+
+`generated.env` is created at runtime by `azure_setup.sh` (the automatic Azure→GCP handoff) and is **not** committed.
+
+## Disclaimer
+
+This is a sample integration and may require modifications to fit your specific security and operational requirements.

--- a/apihub-plugins/azure-apim-onramp-realtime/azure_setup.sh
+++ b/apihub-plugins/azure-apim-onramp-realtime/azure_setup.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Azure side of the Azure APIM -> API Hub real-time on-ramp.
+# Idempotent: re-running reuses existing resources and never hard-fails on "already exists".
+# Run from the plugin folder, after: source env.sh
+set -euo pipefail
+
+# ---------- config (from env.sh) ----------
+: "${AZURE_SUBSCRIPTION_ID:?set it in env.sh}"
+: "${RESOURCE_GROUP:?}"; : "${APIM_NAME:?}"
+: "${GCP_PROJECT:?}"; : "${GCP_PROJECT_NUMBER:?}"; : "${APIHUB_LOCATION:?}"
+: "${INSTANCE_ID:?}"; : "${APIHUB_HOST:?}"
+DEPLOYMENT_TYPE_ID="${DEPLOYMENT_TYPE_ID:-azure-apim}"
+POOL_ID="${POOL_ID:-apihub-azure-onramp-pool}"
+PROVIDER_ID="${PROVIDER_ID:-azure-apim-oidc}"
+SA_NAME="${SA_NAME:-apihub-azure-onramp-sa}"
+APP_DISPLAY_NAME="${APP_DISPLAY_NAME:-apihub-onramp-wif}"
+ENABLE_APP_INSIGHTS="${ENABLE_APP_INSIGHTS:-false}"   # optional: function logs
+TAGS="${TAGS:-{}}"
+
+az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+TENANT_ID="$(az account show --query tenantId -o tsv)"
+
+echo "== [1/8] Register resource providers (idempotent) =="
+for p in Microsoft.EventGrid Microsoft.Web Microsoft.Storage Microsoft.ManagedIdentity; do
+  az provider register -n "$p" --wait >/dev/null || echo "  (could not register $p - may need an admin; continuing)"
+done
+if [[ "$ENABLE_APP_INSIGHTS" == "true" ]]; then
+  az provider register -n microsoft.insights --wait >/dev/null || true
+fi
+
+echo "== [2/8] Resolve APIM (id + region) =="
+APIM_ID="$(az apim show -n "$APIM_NAME" -g "$RESOURCE_GROUP" --query id -o tsv)"
+AZLOC="$(az apim show -n "$APIM_NAME" -g "$RESOURCE_GROUP" --query location -o tsv | tr '[:upper:]' '[:lower:]' | tr -d ' ')"
+echo "   APIM_ID=$APIM_ID   region=$AZLOC"
+
+echo "== [3/8] App Registration (create or reuse) =="
+if [[ -n "${APP_ID:-}" ]]; then
+  echo "   using APP_ID from env: $APP_ID"
+else
+  APP_ID="$(az ad app list --filter "displayName eq '$APP_DISPLAY_NAME'" --query '[0].appId' -o tsv 2>/dev/null || true)"
+  if [[ -z "$APP_ID" || "$APP_ID" == "None" ]]; then
+    if ! APP_ID="$(az ad app create --display-name "$APP_DISPLAY_NAME" --sign-in-audience AzureADMyOrg --query appId -o tsv 2>/tmp/aderr)"; then
+      echo "ERROR: cannot create the App Registration:"; sed 's/^/   /' /tmp/aderr
+      echo "   -> App registration is enabled by default; if your tenant disabled it, get 'Application Developer'"
+      echo "      or have an admin create the app and set APP_ID in env.sh, then re-run."
+      exit 1
+    fi
+  fi
+fi
+az ad sp create --id "$APP_ID" >/dev/null 2>&1 || true
+az ad app update --id "$APP_ID" --identifier-uris "api://$APP_ID"
+echo "   APP_ID=$APP_ID"
+
+echo "== [4/8] Deploy infra (Bicep; idempotent) =="
+az deployment group create -g "$RESOURCE_GROUP" -f main.bicep -p \
+  apimName="$APIM_NAME" location="$AZLOC" appId="$APP_ID" tags="$TAGS" \
+  enableAppInsights="$ENABLE_APP_INSIGHTS" \
+  gcpProject="$GCP_PROJECT" projectNumber="$GCP_PROJECT_NUMBER" \
+  gcpLocation="$APIHUB_LOCATION" instanceId="$INSTANCE_ID" \
+  apihubHost="$APIHUB_HOST" deploymentTypeId="$DEPLOYMENT_TYPE_ID" \
+  poolId="$POOL_ID" providerId="$PROVIDER_ID" saName="$SA_NAME" -o none
+O="$(az deployment group show -g "$RESOURCE_GROUP" -n main --query properties.outputs)"
+FUNC="$(echo "$O" | jq -r .functionAppName.value)"
+MI_OID="$(echo "$O" | jq -r .uamiPrincipalId.value)"
+echo "   FUNC=$FUNC   MI_OID=$MI_OID"
+
+echo "== [5/8] Publish the function (writes local.settings.json) =="
+cat > local.settings.json <<'JSON'
+{ "IsEncrypted": false, "Values": { "FUNCTIONS_WORKER_RUNTIME": "node", "AzureWebJobsStorage": "" } }
+JSON
+npm install
+func azure functionapp publish "$FUNC" || func azure functionapp publish "$FUNC" --javascript
+
+echo "== [6/8] Enable APIM system-assigned identity (idempotent; needed for Event Grid) =="
+az resource update --ids "$APIM_ID" --set identity.type=SystemAssigned -o none
+
+echo "== [7/8] Event Grid subscription APIM -> function (create or reuse) =="
+if az eventgrid event-subscription show --name apihub-onramp-sync --source-resource-id "$APIM_ID" >/dev/null 2>&1; then
+  echo "   subscription already exists; skipping"
+else
+  FUNC_ID="$(az functionapp show -n "$FUNC" -g "$RESOURCE_GROUP" --query id -o tsv)"
+  az eventgrid event-subscription create --name apihub-onramp-sync \
+    --source-resource-id "$APIM_ID" --endpoint-type azurefunction \
+    --endpoint "${FUNC_ID}/functions/onrampApimSync" \
+    --included-event-types Microsoft.ApiManagement.APICreated \
+       Microsoft.ApiManagement.APIUpdated Microsoft.ApiManagement.APIDeleted
+fi
+
+echo "== [8/8] Write generated.env for the GCP step =="
+cat > generated.env <<EOF
+export AZURE_TENANT_ID=$TENANT_ID
+export AZURE_APP_ID=$APP_ID
+export AZURE_MI_OBJECT_ID=$MI_OID
+EOF
+echo "DONE. Next: ./gcp_setup.sh  (auto-loads generated.env)"

--- a/apihub-plugins/azure-apim-onramp-realtime/cleanup.sh
+++ b/apihub-plugins/azure-apim-onramp-realtime/cleanup.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Tear down everything the sample created. Ignores missing resources.
+# Run from the plugin folder, after: source env.sh
+set -uo pipefail
+if [[ -f generated.env ]]; then source generated.env || true; fi
+
+: "${RESOURCE_GROUP:?}"; : "${APIM_NAME:?}"
+: "${GCP_PROJECT:?}"; : "${GCP_PROJECT_NUMBER:?}"
+POOL_ID="${POOL_ID:-apihub-azure-onramp-pool}"
+PROVIDER_ID="${PROVIDER_ID:-azure-apim-oidc}"
+SA_NAME="${SA_NAME:-apihub-azure-onramp-sa}"
+SA_EMAIL="${SA_NAME}@${GCP_PROJECT}.iam.gserviceaccount.com"
+
+APIM_ID="$(az apim show -n "$APIM_NAME" -g "$RESOURCE_GROUP" --query id -o tsv 2>/dev/null || true)"
+
+echo "== Azure: Event Grid subscription =="
+if [[ -n "$APIM_ID" ]]; then
+  az eventgrid event-subscription delete --name apihub-onramp-sync --source-resource-id "$APIM_ID" 2>/dev/null || true
+fi
+
+echo "== Azure: Function / plan / identity / App Insights / Log Analytics / storage =="
+az functionapp delete -g "$RESOURCE_GROUP" -n func-apihub-onramp 2>/dev/null || true
+az appservice plan delete -g "$RESOURCE_GROUP" -n plan-apihub-onramp --yes 2>/dev/null || true
+az identity delete -g "$RESOURCE_GROUP" -n id-apihub-onramp 2>/dev/null || true
+az monitor app-insights component delete -g "$RESOURCE_GROUP" --app appi-apihub-onramp 2>/dev/null || true
+az monitor log-analytics workspace delete -g "$RESOURCE_GROUP" -n law-apihub-onramp --yes 2>/dev/null || true
+for s in $(az storage account list -g "$RESOURCE_GROUP" --query "[?starts_with(name,'stapihubonramp')].name" -o tsv 2>/dev/null); do
+  az storage account delete -g "$RESOURCE_GROUP" -n "$s" --yes 2>/dev/null || true
+done
+
+echo "== Azure: App Registration =="
+if [[ -n "${AZURE_APP_ID:-}" ]]; then
+  az ad app delete --id "$AZURE_APP_ID" 2>/dev/null || true
+else
+  AID="$(az ad app list --filter "displayName eq 'apihub-onramp-wif'" --query '[0].appId' -o tsv 2>/dev/null || true)"
+  if [[ -n "$AID" && "$AID" != "None" ]]; then
+    az ad app delete --id "$AID" 2>/dev/null || true
+  fi
+fi
+# APIM system identity is left enabled (harmless). To remove:
+# [[ -n "$APIM_ID" ]] && az resource update --ids "$APIM_ID" --set identity.type=None -o none || true
+
+echo "== GCP: provider / pool / service account =="
+gcloud iam workload-identity-pools providers delete "$PROVIDER_ID" \
+  --location=global --workload-identity-pool="$POOL_ID" --quiet 2>/dev/null || true
+gcloud iam workload-identity-pools delete "$POOL_ID" --location=global --quiet 2>/dev/null || true
+gcloud iam service-accounts delete "$SA_EMAIL" --quiet 2>/dev/null || true
+
+echo "DONE. (API Hub plugin instance left intact - delete manually only if it was created just for this test.)"

--- a/apihub-plugins/azure-apim-onramp-realtime/env.sh
+++ b/apihub-plugins/azure-apim-onramp-realtime/env.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# env.sh — fill in every <PLACEHOLDER>, then: source env.sh
+# RG + APIM + API Hub instance are your existing resources; the scripts create everything else.
+
+# ---- Azure ----
+export AZURE_SUBSCRIPTION_ID="<AZURE_SUBSCRIPTION_ID>"
+export RESOURCE_GROUP="<RESOURCE_GROUP>"          # the RG that already holds your APIM
+export APIM_NAME="<APIM_SERVICE>"
+
+# ---- Google Cloud ----
+export GCP_PROJECT="<GCP_PROJECT>"                # API Hub host project
+export GCP_PROJECT_NUMBER="<PROJECT_NUMBER>"
+export APIHUB_LOCATION="<APIHUB_REGION>"          # e.g. europe-west1
+export INSTANCE_ID="<PLUGIN_INSTANCE_ID>"        # existing system-azure-apim instance id
+export APIHUB_HOST="https://apihub.googleapis.com"
+
+# ---- optional ----
+# export ENABLE_APP_INSIGHTS=true              # optional: function logs via Application Insights (default: off)
+# export APP_ID=<APP_ID>                        # ONLY if an admin pre-created the App Registration for you
+# export POOL_ID=apihub-azure-onramp-pool
+# export PROVIDER_ID=azure-apim-oidc
+# export SA_NAME=apihub-azure-onramp-sa
+# export TAGS='{"env":"dev","owner":"you"}'

--- a/apihub-plugins/azure-apim-onramp-realtime/gcp_setup.sh
+++ b/apihub-plugins/azure-apim-onramp-realtime/gcp_setup.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Google Cloud side (WIF pool/provider + service account + impersonation).
+# Idempotent: reuses existing resources; handles WIF pool soft-delete.
+# Auto-loads generated.env (from azure_setup.sh) + env.sh. Run from the plugin folder.
+set -euo pipefail
+
+[[ -f generated.env ]] && source generated.env
+[[ -f env.sh ]] && source env.sh
+
+: "${GCP_PROJECT:?}"; : "${GCP_PROJECT_NUMBER:?}"
+: "${AZURE_TENANT_ID:?run azure_setup.sh first (produces generated.env)}"
+: "${AZURE_APP_ID:?}"; : "${AZURE_MI_OBJECT_ID:?}"
+POOL_ID="${POOL_ID:-apihub-azure-onramp-pool}"
+PROVIDER_ID="${PROVIDER_ID:-azure-apim-oidc}"
+SA_NAME="${SA_NAME:-apihub-azure-onramp-sa}"
+SA_EMAIL="${SA_NAME}@${GCP_PROJECT}.iam.gserviceaccount.com"
+
+gcloud config set project "$GCP_PROJECT" >/dev/null
+
+echo "== [1/5] Enable APIs =="
+gcloud services enable sts.googleapis.com iamcredentials.googleapis.com iam.googleapis.com apihub.googleapis.com
+
+echo "== [2/5] Service account (create or reuse) =="
+gcloud iam service-accounts describe "$SA_EMAIL" >/dev/null 2>&1 \
+  || gcloud iam service-accounts create "$SA_NAME" --display-name="Azure APIM real-time on-ramp"
+gcloud projects add-iam-policy-binding "$GCP_PROJECT" \
+  --member="serviceAccount:${SA_EMAIL}" --role="roles/apihub.editor" --condition=None >/dev/null
+
+echo "== [3/5] WIF pool (create/reuse; undelete if soft-deleted) =="
+if gcloud iam workload-identity-pools describe "$POOL_ID" --location=global >/dev/null 2>&1; then
+  STATE="$(gcloud iam workload-identity-pools describe "$POOL_ID" --location=global --format='value(state)')"
+  [[ "$STATE" == "DELETED" ]] && gcloud iam workload-identity-pools undelete "$POOL_ID" --location=global
+  echo "   pool exists ($STATE)"
+else
+  gcloud iam workload-identity-pools create "$POOL_ID" --location=global --display-name="Azure onramp pool"
+fi
+
+echo "== [4/5] OIDC provider (create or reuse) =="
+if gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
+     --location=global --workload-identity-pool="$POOL_ID" >/dev/null 2>&1; then
+  echo "   provider exists; skipping"
+else
+  gcloud iam workload-identity-pools providers create-oidc "$PROVIDER_ID" \
+    --location=global --workload-identity-pool="$POOL_ID" \
+    --issuer-uri="https://sts.windows.net/${AZURE_TENANT_ID}/" \
+    --allowed-audiences="api://${AZURE_APP_ID}" \
+    --attribute-mapping="google.subject=assertion.sub"
+fi
+
+echo "== [5/5] Impersonation binding (idempotent) =="
+gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principal://iam.googleapis.com/projects/${GCP_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/subject/${AZURE_MI_OBJECT_ID}" >/dev/null
+
+echo "DONE. WIF trust established. Create/update an API in APIM to test end-to-end."

--- a/apihub-plugins/azure-apim-onramp-realtime/host.json
+++ b/apihub-plugins/azure-apim-onramp-realtime/host.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/apihub-plugins/azure-apim-onramp-realtime/main.bicep
+++ b/apihub-plugins/azure-apim-onramp-realtime/main.bicep
@@ -1,0 +1,140 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Azure infra for the real-time Azure APIM -> API Hub on-ramp.
+// Graph-free (App Registration is created by azure_setup.sh and passed as appId).
+// Idempotent by nature (re-deploy converges; no "already exists" errors).
+
+targetScope = 'resourceGroup'
+
+@description('Name of the EXISTING APIM service in this resource group')
+param apimName string
+@description('Region for created resources (azure_setup.sh passes the APIM region)')
+param location string
+@description('App (client) ID of the pre-created App Registration = WIF audience')
+param appId string
+@description('Tags applied to all created resources')
+param tags object = {}
+@description('Optional: create Application Insights + Log Analytics for function logs')
+param enableAppInsights bool = false
+
+param gcpProject string
+param projectNumber string
+param gcpLocation string
+param instanceId string
+param poolId string = 'apihub-azure-onramp-pool'
+param providerId string = 'azure-apim-oidc'
+param saName string = 'apihub-azure-onramp-sa'
+param apihubHost string = 'https://apihub.googleapis.com'
+param pluginId string = 'system-azure-apim'
+param deploymentTypeId string = 'azure-apim'
+param apimApiVersion string = '2024-05-01'
+
+resource apim 'Microsoft.ApiManagement/service@2023-05-01-preview' existing = { name: apimName }
+
+var sfx       = uniqueString(resourceGroup().id)
+var funcName  = 'func-apihub-onramp'
+var planName  = 'plan-apihub-onramp'
+var uamiName  = 'id-apihub-onramp'
+var lawName   = 'law-apihub-onramp'
+var appiName  = 'appi-apihub-onramp'
+var storageNm = toLower('stapihubonramp${substring(sfx, 0, 6)}')
+var wifAud    = '//iam.googleapis.com/projects/${projectNumber}/locations/global/workloadIdentityPools/${poolId}/providers/${providerId}'
+var saEmail   = '${saName}@${gcpProject}.iam.gserviceaccount.com'
+
+resource uami 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: uamiName
+  location: location
+  tags: tags
+}
+
+// ---- Optional Application Insights (workspace-based) for function logs ----
+resource law 'Microsoft.OperationalInsights/workspaces@2023-09-01' = if (enableAppInsights) {
+  name: lawName
+  location: location
+  tags: tags
+  properties: { sku: { name: 'PerGB2018' }, retentionInDays: 30 }
+}
+resource appi 'Microsoft.Insights/components@2020-02-02' = if (enableAppInsights) {
+  name: appiName
+  location: location
+  kind: 'web'
+  tags: tags
+  properties: { Application_Type: 'web', WorkspaceResourceId: law.id }
+}
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageNm
+  location: location
+  tags: tags
+  sku: { name: 'Standard_LRS' }
+  kind: 'StorageV2'
+  properties: { minimumTlsVersion: 'TLS1_2', allowBlobPublicAccess: false }
+}
+resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: planName
+  location: location
+  tags: tags
+  sku: { name: 'Y1', tier: 'Dynamic' }
+  kind: 'functionapp'
+  properties: { reserved: true }
+}
+resource func 'Microsoft.Web/sites@2023-12-01' = {
+  name: funcName
+  location: location
+  tags: tags
+  kind: 'functionapp,linux'
+  identity: { type: 'UserAssigned', userAssignedIdentities: { '${uami.id}': {} } }
+  properties: {
+    serverFarmId: plan.id
+    httpsOnly: true
+    siteConfig: {
+      linuxFxVersion: 'Node|20'
+      appSettings: concat([
+        { name: 'AzureWebJobsStorage', value: 'DefaultEndpointsProtocol=https;AccountName=${storage.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storage.listKeys().keys[0].value}' }
+        { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
+        { name: 'FUNCTIONS_WORKER_RUNTIME', value: 'node' }
+        { name: 'AZURE_CLIENT_ID', value: uami.properties.clientId }
+        { name: 'AZURE_TENANT_ID', value: tenant().tenantId }
+        { name: 'WIF_APP_ID_URI', value: 'api://${appId}' }
+        { name: 'WIF_AUDIENCE', value: wifAud }
+        { name: 'WIF_SA_EMAIL', value: saEmail }
+        { name: 'PROJECT', value: gcpProject }
+        { name: 'LOCATION', value: gcpLocation }
+        { name: 'APIHUB_HOST', value: apihubHost }
+        { name: 'INSTANCE_ID', value: instanceId }
+        { name: 'PLUGIN_ID', value: pluginId }
+        { name: 'DEPLOYMENT_TYPE_ID', value: deploymentTypeId }
+        { name: 'APIM_API_VERSION', value: apimApiVersion }
+      ], enableAppInsights ? [
+        { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appi.properties.ConnectionString }
+      ] : [])
+    }
+  }
+}
+
+// ---- Reader on the existing APIM for the function's identity ----
+var readerRole = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+resource reader 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(apim.id, uami.id, readerRole)
+  scope: apim
+  properties: {
+    roleDefinitionId: readerRole
+    principalId: uami.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output uamiPrincipalId string = uami.properties.principalId
+output functionAppName string  = func.name
+output wifAudience string       = wifAud

--- a/apihub-plugins/azure-apim-onramp-realtime/package.json
+++ b/apihub-plugins/azure-apim-onramp-realtime/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "azure-apim-onramp-realtime",
+  "version": "1.0.0",
+  "main": "src/functions/*.js",
+  "dependencies": {
+    "@azure/functions": "^4.5.0"
+  }
+}

--- a/apihub-plugins/azure-apim-onramp-realtime/src/functions/onrampApimSync.js
+++ b/apihub-plugins/azure-apim-onramp-realtime/src/functions/onrampApimSync.js
@@ -1,0 +1,901 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const {app} = require('@azure/functions');
+
+// =============================================================================
+// Azure APIM -> API Hub event-driven push (Event Grid).
+//
+// Forwards real-time APIM API create/update/delete events to API Hub's
+// collectApiData endpoint so a change is reflected in near real time. Each push
+// UPSERTs API Hub resources (APIs, versions, deployments, specs, attributes)
+// using stable original_ids, so repeated pushes converge instead of creating
+// duplicates.
+//
+// Auth to Google Cloud uses Workload Identity Federation: the Function's Azure
+// managed identity is exchanged for a short-lived Google access token, so no
+// long-lived secret is stored.
+// =============================================================================
+
+// ---- env --------------------------------------------------------------
+const APIHUB_HOST =
+    process.env.APIHUB_HOST;  // e.g. https://apihub.googleapis.com
+const PROJECT =
+    process.env.PROJECT;  // API Hub host project
+const LOCATION = process.env.LOCATION;  // europe-west1
+const INSTANCE_ID =
+    process.env.INSTANCE_ID;  // REQUIRED - real plugin instance id
+const WIF_AUDIENCE =
+    process.env
+        .WIF_AUDIENCE;  // //iam.googleapis.com/projects/<PN>/locations/global/workloadIdentityPools/apihub-azure-onramp-pool/providers/azure-apim-oidc
+const WIF_SA_EMAIL =
+    process.env
+        .WIF_SA_EMAIL;  // apihub-azure-onramp-sa@<project>.iam.gserviceaccount.com
+const WIF_APP_ID_URI =
+    process.env.WIF_APP_ID_URI;  // api://<APP_ID>  (Azure app registration
+                                 // Application ID URI)
+const AZURE_TENANT_ID =
+    process.env.AZURE_TENANT_ID;  // Entra tenant id (also used in the deployment
+                                  // management_url)
+const AZURE_CLIENT_ID =
+    process.env.AZURE_CLIENT_ID;  // leave UNSET for system-assigned MI
+
+// Registered API Hub plugin id. MUST match your plugin instance resource name:
+// projects/.../plugins/<PLUGIN_ID>/instances/<INSTANCE_ID>.
+const PLUGIN_ID = process.env.PLUGIN_ID || 'system-azure-apim';
+
+// Registered system-deployment-type allowed value. Must match the deployment
+// type configured for your API Hub plugin instance.
+const DEPLOYMENT_TYPE_ID = process.env.DEPLOYMENT_TYPE_ID || 'azure-apim';
+
+// GCP identity endpoints (prod).
+const STS_URL = process.env.STS_URL || 'https://sts.googleapis.com/v1/token';
+const IAM_CRED_HOST =
+    process.env.IAM_CRED_HOST || 'https://iamcredentials.googleapis.com';
+// Azure platform-injected MI endpoint (Functions; NOT 169.254.169.254).
+const IDENTITY_ENDPOINT = process.env.IDENTITY_ENDPOINT;
+const IDENTITY_HEADER = process.env.IDENTITY_HEADER;
+
+const ARM_RESOURCE = 'https://management.azure.com';
+// 2024-05-01 covers the standard API types. Agent (A2A) APIs surface their
+// fields only on newer preview versions -- set APIM_API_VERSION to a 2024-06+
+// preview if you need A2A detection.
+const APIM_API_VERSION = process.env.APIM_API_VERSION || '2024-05-01';
+const COLLECT_URL = `${APIHUB_HOST}/v1/projects/${PROJECT}/locations/${
+    LOCATION}:collectApiData`;
+const PLUGIN_INSTANCE = `projects/${PROJECT}/locations/${LOCATION}/plugins/${
+    PLUGIN_ID}/instances/${INSTANCE_ID}`;
+const ACTION_ID = 'sync-metadata';
+
+// =============================================================================
+// AUTH: Azure managed-identity token -> Google token exchange (STS) -> service
+// account impersonation (Workload Identity Federation).
+// =============================================================================
+
+// ---- WIF diagnostic: decode (do NOT log the raw token) ----------------
+function decodeJwtClaims(jwt) {
+  try {
+    const c =
+        JSON.parse(Buffer.from(jwt.split('.')[1], 'base64').toString('utf8'));
+    return {
+      iss: c.iss,
+      aud: c.aud,
+      sub: c.sub,
+      oid: c.oid,
+      appid: c.appid,
+      ver: c.ver,
+      tid: c.tid
+    };
+  } catch (e) {
+    return {decodeError: e.message};
+  }
+}
+
+// ---- Azure MI token ---------------------------------------------------
+async function getAzureToken(resource) {
+  if (!IDENTITY_ENDPOINT || !IDENTITY_HEADER)
+    throw new Error(
+        'MI endpoint missing - is system-assigned identity enabled on the Function?');
+  const u = new URL(IDENTITY_ENDPOINT);
+  u.searchParams.set('resource', resource);
+  u.searchParams.set('api-version', '2019-08-01');
+  if (AZURE_CLIENT_ID) u.searchParams.set('client_id', AZURE_CLIENT_ID);
+  const r = await fetch(u, {headers: {'X-IDENTITY-HEADER': IDENTITY_HEADER}});
+  if (!r.ok) throw new Error(`MI token HTTP ${r.status}: ${await r.text()}`);
+  const d = await r.json();
+  if (!d.access_token)
+    throw new Error('MI token response missing access_token');
+  return d.access_token;
+}
+
+// ---- GCP WIF chain ----------------------------------------------------
+let cachedToken = null, cachedExp = 0;
+async function fetchApiHubToken() {
+  const now = Math.floor(Date.now() / 1000);
+  if (cachedToken && cachedExp - now > 300) return cachedToken;
+  // ---- fail fast on misconfiguration (clear errors instead of opaque 400s)
+  // ----
+  if (!WIF_AUDIENCE || !WIF_AUDIENCE.startsWith('//iam.googleapis.com/'))
+    throw new Error(
+        `WIF_AUDIENCE missing/malformed (must start with //iam.googleapis.com/). Got: [${
+            WIF_AUDIENCE}]`);
+  if (!WIF_APP_ID_URI)
+    throw new Error('WIF_APP_ID_URI not set (expected api://<APP_ID>).');
+  if (!WIF_SA_EMAIL) throw new Error('WIF_SA_EMAIL not set.');
+  if (!INSTANCE_ID)
+    throw new Error(
+        'INSTANCE_ID not set - plugin_instance is REQUIRED by collectApiData.');
+  const subjectToken = await getAzureToken(WIF_APP_ID_URI);
+  // ---- WIF token diagnostics (decoded claims only; never the raw token) ----
+  console.log(
+      'AZURE_TOKEN_CLAIMS ' + JSON.stringify(decodeJwtClaims(subjectToken)));
+  console.log(
+      'STS_AUDIENCE_SENT [' + WIF_AUDIENCE +
+      '] len=' + (WIF_AUDIENCE || '').length);
+  console.log('STS_ENDPOINT ' + STS_URL);
+  console.log('PLUGIN_INSTANCE ' + PLUGIN_INSTANCE);
+  // ------------------------------------------------
+  const stsBody = new URLSearchParams({
+    audience: WIF_AUDIENCE,
+    grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+    requested_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+    scope: 'https://www.googleapis.com/auth/cloud-platform',
+    subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+    subject_token: subjectToken,
+  });
+  const sts = await fetch(STS_URL, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    body: stsBody,
+  });
+  if (!sts.ok) throw new Error(`STS HTTP ${sts.status}: ${await sts.text()}`);
+  const fed = (await sts.json()).access_token;
+  const imp = await fetch(
+      `${IAM_CRED_HOST}/v1/projects/-/serviceAccounts/${
+          encodeURIComponent(WIF_SA_EMAIL)}:generateAccessToken`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${fed}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          scope: ['https://www.googleapis.com/auth/cloud-platform'],
+          lifetime: '3600s'
+        })
+      });
+  if (!imp.ok)
+    throw new Error(`impersonation HTTP ${imp.status}: ${await imp.text()}`);
+  const j = await imp.json();
+  cachedToken = j.accessToken;
+  cachedExp = Math.floor(new Date(j.expireTime).getTime() / 1000);
+  return cachedToken;
+}
+
+// =============================================================================
+// END AUTH
+// =============================================================================
+
+const nowIso = () => new Date().toISOString();
+
+// ---- API Hub attribute ids -------------------------------------------
+const ATTR_PRODUCTS = 'plugin-azure-apim-products';
+const ATTR_TAGS = 'plugin-azure-apim-api-tags';
+const ATTR_REVISION = 'plugin-azure-apim-revision';
+const ATTR_SUBSCRIPTION_REQUIRED = 'plugin-azure-apim-subscription-required';
+const ATTR_GATEWAY = 'plugin-azure-apim-gateway';
+const SYSTEM_DEPLOYMENT_TYPE_ATTR = 'system-deployment-type';
+const GATEWAY_MANAGED = 'managed';
+const SYNTHETIC_VERSION_ID = 'v1';
+
+// ---- API-style allowed values ----------------------------------------
+const API_STYLE = {
+  http: 'rest',
+  soap: 'soap',
+  graphql: 'graphql',
+  grpc: 'grpc',
+  websocket: 'websocket',
+  odata: 'odata',
+  a2a: 'a2a',  // agentic APIs
+};
+
+// ---- resource-name formatters ----------------------------------------
+const locationResourceName = () => `projects/${PROJECT}/locations/${LOCATION}`;
+const apisResourceName = (apiId) => `${locationResourceName()}/apis/${apiId}`;
+const attributeResourceName = (attrId) =>
+    `${locationResourceName()}/attributes/${attrId}`;
+
+// ---- identifier helpers ----------------------------------------------
+// azureBaseAPIID: strip APIM's ";rev=N" suffix. Do NOT lowercase: API Hub keys
+// resources by the apiId/serviceName as-is.
+const azureBaseAPIID = (id) => {
+  const i = (id || '').indexOf(';rev=');
+  return i >= 0 ? id.slice(0, i) : id;
+};
+
+// azureLastSegment: final path segment of an ARM resource id.
+const azureLastSegment = (s) => {
+  s = (s || '').replace(/^\/+|\/+$/g, '');
+  const i = s.lastIndexOf('/');
+  return i >= 0 ? s.slice(i + 1) : s;
+};
+
+// azureResourceURI: the shared original_id prefix and deployment resource_uri.
+// serviceName + apiId are used as-is.
+const azureResourceURI = (scope, apiId) =>
+    `subscriptions/${scope.subscriptionId}/resourceGroups/${
+        scope.resourceGroup}` +
+    `/service/${scope.serviceName}/apis/${apiId}`;
+
+// azureManagementURL: Azure portal deep link to the APIM APIs blade.
+const azureManagementURL = (scope) =>
+    `https://portal.azure.com/#@${AZURE_TENANT_ID}/resource/subscriptions/${
+        scope.subscriptionId}` +
+    `/resourceGroups/${
+        scope.resourceGroup}/providers/Microsoft.ApiManagement/service/${
+        scope.serviceName}/apim-apis`;
+
+// azureGroupKeyAndDisplay: map one event's API to its version-set group. The
+// logical API Hub Api is keyed by the version-set short id (so all versions
+// converge on one Api), or the base apiId when unversioned.
+function azureGroupKeyAndDisplay(api) {
+  const key = api.versionSetId || azureBaseAPIID(api.id);
+  const displayName = (api.versionSetId && api.versionSetName) ?
+      api.versionSetName :
+      (api.displayName || api.id);
+  return {key, displayName};
+}
+
+// classifyAzureApiType: map the APIM api type to an internal type. Agent (A2A)
+// APIs are detected from the raw api-type string ("a2a") returned by the REST
+// response; fetchApimData additionally treats the presence of
+// properties.a2aProperties as A2A.
+function classifyAzureApiType(rawType) {
+  switch ((rawType || '').toLowerCase()) {
+    case 'soap':
+      return 'soap';
+    case 'websocket':
+      return 'websocket';
+    case 'graphql':
+      return 'graphql';
+    case 'grpc':
+      return 'grpc';
+    case 'odata':
+      return 'odata';
+    case 'a2a':
+    case 'agent':
+      return 'a2a';  // agentic; also detected via a2aProperties in
+                     // fetchApimData
+    default:
+      return 'http';
+  }
+}
+
+// azureSpecSources: which spec(s) to fetch per API type.
+//   http -> OpenAPI (export); soap -> WSDL (export);
+//   grpc -> proto, graphql -> SDL, odata -> EDMX (inline schema);
+//   websocket -> none. a2a is NOT in this matrix: its Agent Card spec is
+//   fetched from the gateway by fetchA2AAgentCard (called directly from
+//   fetchApimData).
+function azureSpecSources(apiType) {
+  switch (apiType) {
+    case 'http':
+      return [{
+        export: 'openapi+json-link',
+        specTypeId: 'openapi',
+        mimeType: 'application/json',
+        kind: 'openapi'
+      }];
+    case 'soap':
+      return [{
+        export: 'wsdl-link',
+        specTypeId: 'wsdl',
+        mimeType: 'application/wsdl+xml',
+        kind: 'wsdl'
+      }];
+    case 'grpc':
+      return [{
+        schemaContentType: 'text/protobuf',
+        specTypeId: 'proto',
+        mimeType: 'text/plain',
+        kind: 'proto'
+      }];
+    case 'graphql':
+      return [{
+        schemaContentType: 'application/vnd.ms-azure-apim.graphql.schema',
+        specTypeId: 'sdl',
+        mimeType: 'application/graphql',
+        kind: 'graphql'
+      }];
+    case 'odata':
+      return [{
+        schemaContentType: 'application/vnd.ms-azure-apim.odata.schema',
+        specTypeId: 'edmx',
+        mimeType: 'application/xml',
+        kind: 'odata'
+      }];
+    default:
+      return [];
+  }
+}
+
+// ---- AttributeValues builders ----------------------------------------
+const enumAttr = (id) => ({enumValues: {values: [{id}]}});
+const jsonAttr = (name, jsonStr) =>
+    ({attribute: name, jsonValues: {values: [jsonStr]}});
+const stringAttr = (name, s) =>
+    ({attribute: name, stringValues: {values: [s]}});
+
+// ---- safe URL logging ------------------------------------------------
+function urlHost(raw) {
+  try {
+    const u = new URL(raw);
+    return u.host ? `${u.protocol}//${u.host}` : '<redacted-url>';
+  } catch {
+    return '<redacted-url>';
+  }
+}
+
+// ---- event parsing (APIM-native) --------------------------------------
+function parseResourceUri(uri) {
+  const m = uri?.match(
+      /subscriptions\/([^/]+)\/resourceGroups\/([^/]+)\/providers\/Microsoft\.ApiManagement\/service\/([^/]+)\/apis\/([^/?]+)/i);
+  return m ? {
+    subscriptionId: m[1],
+    resourceGroup: m[2],
+    serviceName: m[3],
+    apiId: m[4]
+  } :
+             null;
+}
+
+function parseEvent(event) {
+  const t = event?.eventType;
+  if (!t?.startsWith('Microsoft.ApiManagement.API')) return null;
+  const raw = event?.data?.resourceUri ||
+      `${event?.topic || ''}/${event?.subject || ''}`;
+  const scope = parseResourceUri(
+      raw.replace(/\/{2,}/g, '/'));  // collapse // from the topic+subject join
+  if (!scope) return null;
+  return {
+    intent: t.endsWith('Deleted') ? 'delete' : 'upsert',
+    // Best-effort display name hint for the delete path (see deleteRequest).
+    displayNameHint: event?.data?.name || event?.data?.title || '',
+    ...scope,
+  };
+}
+
+// ---- concurrency state gate (best-effort, fail-open) ------------------
+async function actionGate(token) {
+  if (!INSTANCE_ID) return 'PROCEED';
+  try {
+    const url = `${APIHUB_HOST}/v1/${PLUGIN_INSTANCE}/actions/${ACTION_ID}`;
+    const r = await fetch(url, {headers: {Authorization: `Bearer ${token}`}});
+    if (!r.ok) return 'PROCEED';
+    const a = await r.json();
+    if (a.state === 'DISABLED') return 'DROP';
+    if (a.currentExecutionState === 'RUNNING') return 'DEFER';
+  } catch { /* fail-open: the periodic sync is the safety net */
+  }
+  return 'PROCEED';
+}
+
+// ---- APIM data fetch (ARM REST) ---------------------------------------
+async function armGet(url, token) {
+  const r = await fetch(url, {headers: {Authorization: `Bearer ${token}`}});
+  if (!r.ok) throw new Error(`ARM ${url} -> ${r.status}: ${await r.text()}`);
+  return r.json();
+}
+
+// listNames pages an ARM collection and returns each entry's display name
+// (falling back to its id). Best-effort: a failure yields "" enrichment, never
+// fails the push.
+async function listNames(url, token, context) {
+  const names = [];
+  let next = url;
+  try {
+    while (next) {
+      const page = await armGet(next, token);
+      for (const v of page.value || []) {
+        const name = v?.properties?.displayName || v?.name;
+        if (name) names.push(name);
+      }
+      next = page.nextLink || null;
+    }
+  } catch (e) {
+    context.log(
+        `enrichment fetch failed (${urlHost(url)}): ${e.message}; continuing`);
+  }
+  return names;
+}
+
+// listGatewayIds pages the service's self-hosted gateways into an array of ids.
+// The built-in managed gateway is queried separately by its reserved "managed"
+// id and is NOT returned here.
+async function listGatewayIds(url, armToken) {
+  const ids = [];
+  let next = url;
+  while (next) {
+    const page = await armGet(next, armToken);
+    for (const g of page.value || [])
+      if (g?.name) ids.push(g.name);
+    next = page.nextLink || null;
+  }
+  return ids;
+}
+
+// listGatewayApiIds pages a gateway's API collection into a Set of API ids.
+// Throws on ARM error so the caller can decide whether a failed read should
+// demote managed membership.
+async function listGatewayApiIds(url, armToken) {
+  const ids = new Set();
+  let next = url;
+  while (next) {
+    const page = await armGet(next, armToken);
+    for (const v of page.value || [])
+      if (v?.name) ids.add(v.name);
+    next = page.nextLink || null;
+  }
+  return ids;
+}
+
+// fetchGatewayInfo resolves gateway membership for a single API:
+//   - managedGatewayUrl: the managed gateway base URL (ServiceClient.Get);
+//     "" -> mapping falls back to the conventional <service>.azure-api.net
+//     host.
+//   - managed: whether the managed gateway still serves this API. Demoted to
+//     false ONLY when the managed-gateway API list is read successfully and
+//     omits this API (so a REMOVED gateway drops the Deployment). Fail-safe:
+//     any read error keeps managed=true so a transient ARM error never silently
+//     drops a live API's endpoint.
+//   - selfHosted: ids of self-hosted gateways also serving this API.
+async function fetchGatewayInfo(base, apiId, armToken, context) {
+  let managedGatewayUrl = '';
+  try {
+    const svc =
+        await armGet(`${base}?api-version=${APIM_API_VERSION}`, armToken);
+    managedGatewayUrl = svc?.properties?.gatewayUrl || '';
+  } catch (e) {
+    context.log(
+        `gateway: service get failed: ${e.message}; using conventional host`);
+  }
+
+  let managed = true;
+  try {
+    const managedApis = await listGatewayApiIds(
+        `${base}/gateways/managed/apis?api-version=${APIM_API_VERSION}`,
+        armToken);
+    managed = managedApis.has(apiId);
+  } catch (e) {
+    context.log(
+        `gateway: managed API list failed: ${e.message}; keeping managed=true`);
+  }
+
+  const selfHosted = [];
+  try {
+    for (const gwId of await listGatewayIds(
+             `${base}/gateways?api-version=${APIM_API_VERSION}`, armToken)) {
+      try {
+        const gwApis = await listGatewayApiIds(
+            `${base}/gateways/${encodeURIComponent(gwId)}/apis?api-version=${
+                APIM_API_VERSION}`,
+            armToken);
+        if (gwApis.has(apiId)) selfHosted.push(gwId);
+      } catch (e) {
+        context.log(
+            `gateway: ${gwId} API list failed: ${e.message}; continuing`);
+      }
+    }
+  } catch (e) {
+    context.log(`gateway: self-hosted list failed: ${e.message}; continuing`);
+  }
+
+  return {managed, managedGatewayUrl, selfHosted};
+}
+
+// exportSpec requests an ARM spec export and downloads it from the returned
+// Blob SAS link.
+async function exportSpec(base, apiId, format, armToken, context) {
+  const exp = await armGet(
+      `${base}/apis/${apiId}?export=true&format=${
+          encodeURIComponent(format)}&api-version=${APIM_API_VERSION}`,
+      armToken);
+  const link = exp?.value?.link ||
+      exp?.properties?.value?.link;  // hoist: properties.value -> value
+  if (!link) return null;
+  context.log(
+      `spec export (${format}) for ${apiId} -> SAS host ${urlHost(link)}`);
+  const sr = await fetch(
+      link);  // SAS URL carries the token; never log it, no auth header
+  if (!sr.ok) throw new Error(`spec download HTTP ${sr.status}`);
+  return Buffer.from(await sr.arrayBuffer());
+}
+
+// fetchSchema returns the inline API schema document of the given content type.
+// Returns null when the API has no such schema, so a missing schema degrades to
+// metadata-only.
+async function fetchSchema(base, apiId, contentType, armToken, context) {
+  const list = await armGet(
+      `${base}/apis/${apiId}/schemas?api-version=${APIM_API_VERSION}`,
+      armToken);
+  let schemaId = '';
+  for (const s of list.value || []) {
+    const ct = s?.properties?.contentType || '';
+    if (ct.toLowerCase().includes(contentType.toLowerCase()))
+      schemaId = s.name;  // substring match
+  }
+  if (!schemaId) {
+    context.log(`API ${apiId} has no ${contentType} schema`);
+    return null;
+  }
+  const doc = await armGet(
+      `${base}/apis/${apiId}/schemas/${schemaId}?api-version=${
+          APIM_API_VERSION}`,
+      armToken);
+  const d = doc?.properties?.document || {};
+  const value =
+      d.value || d.odata;  // hoist: document.odata -> document.value (OData)
+  return value ? Buffer.from(value) : null;
+}
+
+// fetchSpecs gathers every spec the API type carries, skipping sources that
+// fail or return no document. Never throws.
+async function fetchSpecs(base, apiId, apiType, armToken, context) {
+  const out = [];
+  for (const src of azureSpecSources(apiType)) {
+    try {
+      const bytes = src.schemaContentType ?
+          await fetchSchema(
+              base, apiId, src.schemaContentType, armToken, context) :
+          await exportSpec(base, apiId, src.export, armToken, context);
+      if (bytes && bytes.length) {
+        out.push({
+          contentsB64: bytes.toString('base64'),
+          specTypeId: src.specTypeId,
+          mimeType: src.mimeType,
+          kind: src.kind
+        });
+      }
+    } catch (e) {
+      context.log(`spec fetch (${src.kind}) failed for ${apiId}: ${
+          e.message}; continuing`);
+    }
+  }
+  return out;
+}
+
+// fetchA2AAgentCard returns the A2A "spec" -- the Agent Card JSON -- as a
+// single spec entry (spec type a2a-agent-card). The card is served by the APIM
+// gateway (a fixed, egress-safe host) at properties.a2aProperties.agentCardPath
+// (default /agent-card.json); A2A gateway APIs are subscriptionRequired=false
+// so the GET is unauthenticated. Best-effort: a miss yields metadata-only (no
+// spec), never throws. Mechanism verified with testing_spec/a2atest.
+async function fetchA2AAgentCard(scope, api, props, context) {
+  try {
+    const a2a = props.a2aProperties || {};
+    const cardPath = a2a.agentCardPath || '/agent-card.json';
+    const card = cardPath.startsWith('/') ? cardPath : '/' + cardPath;
+    const gatewayHost = scope.serviceName.toLowerCase() + '.azure-api.net';
+    const apiPath = (api.path || '').replace(/^\/+|\/+$/g, '');
+    const url = apiPath ? `https://${gatewayHost}/${apiPath}${card}` :
+                          `https://${gatewayHost}${card}`;
+    context.log(`A2A agent card fetch: GET ${url}`);
+    const r = await fetch(url, {headers: {Accept: 'application/json'}});
+    if (!r.ok) {
+      context.log(
+          `A2A agent card GET -> HTTP ${r.status}; publishing metadata-only`);
+      return [];
+    }
+    const bytes = Buffer.from(await r.arrayBuffer());
+    if (!bytes.length) return [];
+    return [{
+      contentsB64: bytes.toString('base64'),
+      specTypeId: 'a2a-agent-card',
+      mimeType: 'application/json',
+      kind: 'agent-card',
+    }];
+  } catch (e) {
+    context.log(
+        `A2A agent card fetch failed: ${e.message}; publishing metadata-only`);
+    return [];
+  }
+}
+
+// fetchApimData reads one API (identity from the event scope) into the
+// normalized shape used to build the API Hub payload.
+async function fetchApimData(scope, context) {
+  const armToken = await getAzureToken(ARM_RESOURCE);
+  const apiId = scope.apiId;  // current-revision apiId (as-is)
+  const base =
+      `${ARM_RESOURCE}/subscriptions/${scope.subscriptionId}/resourceGroups/${
+          scope.resourceGroup}` +
+      `/providers/Microsoft.ApiManagement/service/${scope.serviceName}`;
+
+  const apiResp = await armGet(
+      `${base}/apis/${apiId}?api-version=${APIM_API_VERSION}`, armToken);
+  const p = apiResp.properties || {};
+
+  // Version set: prefer the inline object, else resolve the name from the id.
+  let versionSetId = '', versionSetName = '';
+  if (p.apiVersionSet && (p.apiVersionSet.id || p.apiVersionSet.name)) {
+    versionSetId = azureLastSegment(p.apiVersionSet.id || '');
+    versionSetName = p.apiVersionSet.name || '';
+  }
+  if (!versionSetId && p.apiVersionSetId)
+    versionSetId = azureLastSegment(p.apiVersionSetId);
+  if (versionSetId && !versionSetName) {
+    try {
+      const vs = await armGet(
+          `${base}/apiVersionSets/${versionSetId}?api-version=${
+              APIM_API_VERSION}`,
+          armToken);
+      versionSetName = vs?.properties?.displayName || '';
+    } catch (e) {
+      context.log(`version set ${versionSetId} lookup failed: ${
+          e.message}; continuing`);
+    }
+  }
+
+  // A2A detection: the raw REST response carries either type=="a2a" or a
+  // properties.a2aProperties block.
+  let apiType = classifyAzureApiType(p.type || p.apiType);
+  if (apiType !== 'a2a' && p.a2aProperties) apiType = 'a2a';
+
+  const api = {
+    id: apiId,
+    displayName: p.displayName || '',
+    description: p.description || '',
+    path: (p.path || '').replace(/^\/+/, ''),
+    apiType,
+    revision: p.apiRevision || '',
+    isCurrent: p.isCurrent !== false,
+    version: p.apiVersion || '',
+    versionSetId,
+    versionSetName,
+    subscriptionRequired: !!p.subscriptionRequired,
+    products: await listNames(
+        `${base}/apis/${apiId}/products?api-version=${APIM_API_VERSION}`,
+        armToken, context),
+    tags: await listNames(
+        `${base}/apis/${apiId}/tags?api-version=${APIM_API_VERSION}`, armToken,
+        context),
+  };
+
+  // Gateway membership (managed URL, managed vs. removed, self-hosted).
+  // Drives whether a Deployment is emitted below.
+  const gw = await fetchGatewayInfo(base, apiId, armToken, context);
+  api.managed = gw.managed;
+  api.managedGatewayUrl = gw.managedGatewayUrl;
+  api.selfHosted = gw.selfHosted;
+
+  // A2A APIs carry no schema resource; their "spec" is the Agent Card served by
+  // the gateway. Everything else uses the export/inline-schema matrix.
+  const specs = api.apiType === 'a2a' ?
+      await fetchA2AAgentCard(scope, api, p, context) :
+      await fetchSpecs(base, apiId, api.apiType, armToken, context);
+  return {api, specs};
+}
+
+// ---- payload builders ------------------------------------------------
+
+// buildVersionMetadata: version attributes + managed-gateway Deployment + specs.
+function buildVersionMetadata(scope, api, specs) {
+  const versionId = api.version || SYNTHETIC_VERSION_ID;
+  const resourceUri = azureResourceURI(scope, api.id);
+  const now = nowIso();
+
+  // ----- version-scoped attributes (order-independent; keys are resource
+  // names)
+  const attributes = {};
+  const tagsJSON =
+      (api.tags && api.tags.length) ? JSON.stringify(api.tags) : '';
+  if (tagsJSON) {
+    const n = attributeResourceName(ATTR_TAGS);
+    attributes[n] = jsonAttr(n, tagsJSON);
+  }
+  const productsJSON =
+      (api.products && api.products.length) ? JSON.stringify(api.products) : '';
+  if (productsJSON) {
+    const n = attributeResourceName(ATTR_PRODUCTS);
+    attributes[n] = jsonAttr(n, productsJSON);
+  }
+  if (api.revision) {
+    const n = attributeResourceName(ATTR_REVISION);
+    attributes[n] = stringAttr(n, api.revision);
+  }
+  {
+    const n = attributeResourceName(ATTR_SUBSCRIPTION_REQUIRED);
+    attributes[n] =
+        stringAttr(n, String(!!api.subscriptionRequired));  // always stamped
+  }
+
+  // ----- deployment: managed gateway ONLY. A version served by no managed
+  // gateway has no reachable endpoint, so NO Deployment is emitted -- the
+  // Version + Spec are still upserted. This is what makes an update that
+  // REMOVES the gateway drop the stale deployment/endpoint on the next push
+  // instead of leaving a dangling endpoint. NOTE: removal takes effect only if
+  // API Hub replaces a version's deployments on UPSERT. If deployments are
+  // merged instead, a gateway removal also needs an explicit deployment DELETE.
+  const deployments = [];
+  if (api.managed) {
+    const gatewayUrl = api.managedGatewayUrl ||
+        ('https://' + scope.serviceName.toLowerCase() + '.azure-api.net');
+    let gatewayHost = gatewayUrl;
+    try {
+      gatewayHost = new URL(gatewayUrl).hostname;
+    } catch { /* keep raw */
+    }
+    const scheme = api.apiType === 'websocket' ? 'wss' : 'https';
+    let endpoint = `${scheme}://${gatewayHost}`;
+    if (api.path) endpoint = `${endpoint}/${api.path.replace(/^\/+/, '')}`;
+
+    // gateway attribute {gateway, gatewayUrl[, selfHosted]}: key order and the
+    // omitempty on selfHosted match Go's json.Marshal of azureGatewayAttr.
+    const gwObj = {gateway: GATEWAY_MANAGED, gatewayUrl};
+    if (api.selfHosted && api.selfHosted.length) {
+      gwObj.selfHosted = api.selfHosted.map((id) => ({id}));
+    }
+    const gatewayAttrName = attributeResourceName(ATTR_GATEWAY);
+
+    deployments.push({
+      deployment: {
+        displayName: scope.serviceName,  // the APIM service name
+        deploymentType: {
+          attribute: attributeResourceName(SYSTEM_DEPLOYMENT_TYPE_ATTR),
+          enumValues: {values: [{id: DEPLOYMENT_TYPE_ID}]},
+        },
+        resourceUri,
+        managementUrl: {uriValues: {values: [azureManagementURL(scope)]}},
+        endpoints: [endpoint],
+        attributes: {
+          [gatewayAttrName]: jsonAttr(gatewayAttrName, JSON.stringify(gwObj))
+        },
+      },
+      originalId: resourceUri,
+      originalUpdateTime: now,
+    });
+  }
+
+  // ----- specs (0 or 1 per this version, per the spec-source matrix)
+  const specMetas =
+      (specs ||
+       []).map((s) => ({
+                 spec: {
+                   displayName: `${scope.serviceName}-${versionId}`,
+                   specType: enumAttr(s.specTypeId),
+                   contents: {contents: s.contentsB64, mimeType: s.mimeType},
+                 },
+                 originalId:
+                     `${resourceUri}/versions/${versionId}/specs/${s.kind}`,
+                 originalUpdateTime: now,
+               }));
+
+  const vm = {
+    version: {displayName: versionId, attributes},
+    originalId: `${resourceUri}/versions/${versionId}`,
+    originalUpdateTime: now,
+  };
+  if (deployments.length) vm.deployments = deployments;
+  if (specMetas.length) vm.specs = specMetas;
+  return vm;
+}
+
+// buildApiMetadata: one API Hub Api (keyed by version-set/base id) carrying the
+// event's version. Incremental UPSERT: only this version is sent; sibling
+// versions keep their own original_ids untouched.
+function buildApiMetadata(scope, api, versions) {
+  const {key, displayName} = azureGroupKeyAndDisplay(api);
+  return {
+    api: {
+      name: apisResourceName(key),
+      displayName,
+      description: api.description || '',
+      apiStyle: enumAttr(API_STYLE[api.apiType] || API_STYLE.http),
+      // No fingerprint: API Hub derives one from displayName.
+    },
+    versions,
+    originalId: azureResourceURI(scope, key),
+    originalUpdateTime: nowIso(),
+  };
+}
+
+function upsertRequest(apiMetadata) {
+  return {
+    location: locationResourceName(),
+    collectionType: 'COLLECTION_TYPE_UPSERT',
+    pluginInstance: PLUGIN_INSTANCE,
+    actionId: ACTION_ID,
+    apiData: {apiMetadataList: {apiMetadata: [apiMetadata]}},
+  };
+}
+
+// deleteRequest sends a DELETE op with only api.displayName +
+// originalUpdateTime; API Hub derives the lookup fingerprint from displayName.
+// The API is already gone, so we cannot re-read its display name; we use the
+// event hint, else the base apiId. Deletes are best-effort here -- the periodic
+// sync reconciles authoritatively.
+function deleteRequest(displayName) {
+  return {
+    location: locationResourceName(),
+    collectionType: 'COLLECTION_TYPE_DELETE',
+    pluginInstance: PLUGIN_INSTANCE,
+    actionId: ACTION_ID,
+    apiData: {
+      apiMetadataList:
+          {apiMetadata: [{api: {displayName}, originalUpdateTime: nowIso()}]}
+    },
+  };
+}
+
+async function postCollect(payload, token) {
+  const r = await fetch(COLLECT_URL, {
+    method: 'POST',
+    headers:
+        {Authorization: `Bearer ${token}`, 'Content-Type': 'application/json'},
+    body: JSON.stringify(payload),
+  });
+  const text = await r.text();
+  if (!r.ok) console.error(`collectApiData FAILED ${r.status}: ${text}`);
+  return {ok: r.ok, status: r.status, body: text};
+}
+
+// ---- entry point ------------------------------------------------------
+async function eventGridHandler(event, context) {
+  context.log(`event: ${event?.eventType} subject=${event?.subject}`);
+  const scope = parseEvent(event);
+  if (!scope) return {skipped: 'not an APIM API event'};
+  context.log(
+      `intent=${scope.intent} api=${scope.apiId} svc=${scope.serviceName}`);
+
+  const token = await fetchApiHubToken();
+  const gate = await actionGate(token);
+  if (gate === 'DROP') return {skipped: 'action disabled'};
+  if (gate === 'DEFER')
+    throw new Error('full sync RUNNING - defer via Event Grid retry');
+
+  if (scope.intent === 'delete') {
+    const displayName = scope.displayNameHint || azureBaseAPIID(scope.apiId);
+    const res = await postCollect(deleteRequest(displayName), token);
+    context.log(`delete(displayName=${displayName}) -> ${res.status} ${
+        res.body.slice(0, 500)}`);
+    return res;
+  }
+
+  const {api, specs} = await fetchApimData(scope, context);
+  context.log(
+      `fetched api=${api.id} type=${api.apiType} version=${
+          api.version || SYNTHETIC_VERSION_ID} ` +
+      `versionSet=${api.versionSetId || '-'} managed=${
+          api.managed} selfHosted=${(api.selfHosted || []).length} ` +
+      `specs=${specs.length} products=${api.products.length} tags=${
+          api.tags.length}`);
+  const apiMetadata =
+      buildApiMetadata(scope, api, [buildVersionMetadata(scope, api, specs)]);
+  const res = await postCollect(upsertRequest(apiMetadata), token);
+  context.log(`upsert(originalId=${apiMetadata.originalId}) -> ${res.status} ${
+      res.body.slice(0, 500)}`);
+  return res;
+}
+
+app.eventGrid('onrampApimSync', {handler: eventGridHandler});
+module.exports = {
+  eventGridHandler,
+  parseEvent,
+  classifyAzureApiType,
+  azureSpecSources,
+  azureResourceURI,
+  azureGroupKeyAndDisplay,
+  buildApiMetadata,
+  buildVersionMetadata,
+};


### PR DESCRIPTION
## Summary

Adds `apihub-plugins/azure-apim-onramp-realtime`, an **event-driven** on-ramp plugin that keeps Google Cloud API hub in sync with Azure API Management (APIM) in near real time. It complements the existing batch [`azure-apim`](./apihub-plugins/azure-apim) plugin.

- An **Azure Function** (Event Grid trigger) forwards APIM API **create/update/delete** events to API hub via `collectApiData`, so changes appear within seconds.
- Authenticates to Google Cloud with **keyless Workload Identity Federation** — no long-lived client secret is stored (a key difference from the batch plugin).
- Idempotent, re-runnable setup:
  - `azure_setup.sh` — App Registration, Bicep infra, function publish, APIM managed identity, Event Grid subscription.
  - `gcp_setup.sh` — service account (`roles/apihub.editor`), WIF pool/provider, impersonation binding.
  - `cleanup.sh` — tears everything down.
- `main.bicep` provisions the Function App, storage, plan, user-assigned identity, optional Application Insights, and the APIM `Reader` role assignment.

## Testing

- Verified end-to-end against a live APIM instance and an API hub plugin instance: creating/updating/deleting an API in APIM is reflected in API hub within seconds.
- All checks pass on my fork (MegaLinter, apigeelint, license headers, repo structure, conventional commits).

## Notes

- Listed in the root `README.md` samples table.
- This is a sample integration and may require modifications to fit specific security and operational requirements.
