### PR TITLE
feat(apihub-plugins): add azure-apim-onramp-realtime sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Plugins, also known as *on-ramp plugins*, enable API hub to connect and ingest A
 |     | Sample                   | Description                                                                                                                                                                                                                                                 | 
 | --- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | [azure-apim](./apihub-plugins/azure-apim) | This sample provides an Application Integration template and scripts to synchronize API metadata from Azure API Management (APIM) to Apigee API hub |
+| 2   | [azure/apim](./apihub-plugins/azure/apim) | This sample provides an event-driven real-time on-ramp that syncs Azure API Management (APIM) API metadata into Apigee API hub whenever an API is created, updated, or deleted, via Event Grid + an Azure Function using Workload Identity Federation (no client secrets) |
 
 ## <a name="modifying"></a>Modifying a sample proxy
 

--- a/apihub-plugins/azure/apim/README.md
+++ b/apihub-plugins/azure/apim/README.md
@@ -1,0 +1,444 @@
+<!--
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+# Sync API metadata from Azure API Management to Google Cloud Apigee API hub
+
+This sample covers the one-time plugin instance setup that seeds API hub with
+all existing APIs and supports on-demand re-syncs, plus an optional Azure
+Function deployment that pushes individual APIM control-plane events to API hub
+via Event Grid for continuous synchronization. Authentication for the real-time
+Function to Google Cloud uses Workload Identity Federation — no long-lived
+credentials are stored in Azure.
+
+## Prerequisites
+
+1.  **Azure:** a subscription with an APIM instance to synchronize and
+    permission to create Microsoft Entra ID App Registrations and deploy ARM /
+    Bicep templates (which create a Function App, storage account, App Service
+    plan, user-assigned managed identity, and an Event Grid subscription).
+2.  **Google Cloud:** an API hub-provisioned project. See
+    [Provision API hub](https://cloud.google.com/apigee/docs/apihub/provision).
+3.  **IAM on GCP side:** `roles/apihub.admin`,
+    `roles/iam.workloadIdentityPoolAdmin`, `roles/iam.serviceAccountAdmin`,
+    `roles/secretmanager.admin`, and `roles/resourcemanager.projectIamAdmin` (or
+    `roles/owner`).
+4.  **IAM on Azure side:** `Owner` or `Contributor` on the resource group
+    holding the APIM (to deploy resources), plus `User Access Administrator` (to
+    assign the APIM `Reader` role), and `Application Administrator` at the Entra
+    tenant level (to create the App Registration).
+
+## Values to gather before starting
+
+Substitute these throughout the setup steps.
+
+Placeholder                 | Where to find it
+--------------------------- | ----------------
+`<GCP_PROJECT_ID>`          | Your target API hub project
+`<GCP_PROJECT_NUMBER>`      | Shown below the project ID in the GCP Console picker
+`<GCP_LOCATION>`            | Region where the API hub instance is hosted (e.g., `us-west1`)
+`<PLUGIN_INSTANCE_ID>`      | Auto-generated in [Step 3](#step-3-create-the-api-hub-plugin-instance); visible on the instance details page
+`<AZURE_SUBSCRIPTION_ID>`   | Azure Portal → **Subscriptions**
+`<AZURE_TENANT_ID>`         | Azure Portal → **Microsoft Entra ID → Overview**
+`<AZURE_RESOURCE_GROUP>`    | The RG that already holds your APIM instance
+`<AZURE_APIM_SERVICE>`      | Name of your APIM service
+`<AZURE_APIM_REGION>`       | Region of your APIM (e.g., `eastus`, `westeurope`)
+`<AZURE_APP_CLIENT_ID>`     | Created in [Step 1](#step-1-create-an-entra-app-registration-for-api-hub) (App Registration client id)
+`<AZURE_APP_CLIENT_SECRET>` | Created in [Step 1](#step-1-create-an-entra-app-registration-for-api-hub) (shown once at secret creation)
+`<AZURE_MI_OBJECT_ID>`      | Created in [Step 6](#step-6-deploy-the-bicep-template) (managed identity object id, on the Bicep deployment's Outputs tab)
+`<SECRET_NAME>`             | You choose this in [Step 2](#step-2-store-the-azure-client-secret-in-google-secret-manager) (e.g., `apihub-azure-client-secret`)
+
+## Setup Instructions
+
+Follow these steps in order to configure the API hub plugin instance (Steps 1–3)
+and then, optionally, layer real-time push on top (Steps 4–9).
+
+### Step 1: Create an Entra App Registration for API hub
+
+API hub uses OAuth2-style client credentials to read API metadata from Azure
+APIM. Create a dedicated Entra App Registration with **read-only** access to
+your APIM instance, and generate a client secret for it.
+
+**1.1** In Azure Portal → **Microsoft Entra ID → App registrations → + New
+registration**:
+
+Field                   | Value
+----------------------- | --------------------------------------------------
+Name                    | `apihub-azure-apim` (or anything descriptive)
+Supported account types | **Accounts in this organizational directory only**
+Redirect URI            | Leave blank
+
+Click **Register**.
+
+**1.2** On the app's **Overview** page, copy the **Application (client) ID** —
+this is `<AZURE_APP_CLIENT_ID>`.
+
+**1.3** In the left nav → **Certificates & secrets → + New client secret**.
+
+Field       | Value
+----------- | -----------------------------------------------
+Description | `apihub-plugin-instance`
+Expires     | Pick per your rotation policy (e.g., 12 months)
+
+Click **Add**, then copy the **Value** column immediately — this is
+`<AZURE_APP_CLIENT_SECRET>` and it will not be shown again.
+
+**1.4** Grant the App Registration's service principal the built-in **API
+Management Service Reader Role** on the APIM instance. Azure Portal → open your
+APIM service → left nav → **Access control (IAM) → + Add → Add role
+assignment**.
+
+Field            | Value
+---------------- | -------------------------------------------------
+Role             | **API Management Service Reader Role**
+Assign access to | **User, group, or service principal**
+Members          | Search for `apihub-azure-apim` and select the app
+
+Click **Review + assign**.
+
+> ⚠️ Use **API Management Service Reader Role**, not the built-in **Reader**
+> role. Plain Reader grants ARM-level metadata visibility but not the APIM
+> data-plane reads (`service/apis/read`, `service/apis/schemas/read`, …) the
+> plugin needs; picking the wrong role produces a runtime `403
+> AuthorizationFailed` from the plugin's `sync-metadata` action.
+
+### Step 2: Store the Azure client secret in Google Secret Manager
+
+The API hub plugin instance reads `<AZURE_APP_CLIENT_SECRET>` from a Secret
+Manager secret. The application id is not sensitive and goes directly on the
+plugin instance form.
+
+**2.1** Enable the Secret Manager API (skip if it's already enabled):
+
+```bash
+gcloud services enable secretmanager.googleapis.com \
+  --project=<GCP_PROJECT_ID>
+```
+
+**2.2** Create the secret and add its first version:
+
+```bash
+gcloud secrets create <SECRET_NAME> \
+  --replication-policy=automatic \
+  --project=<GCP_PROJECT_ID>
+
+printf '%s' '<AZURE_APP_CLIENT_SECRET>' | \
+  gcloud secrets versions add <SECRET_NAME> \
+  --data-file=- \
+  --project=<GCP_PROJECT_ID>
+```
+
+Use a descriptive `<SECRET_NAME>` such as `apihub-azure-client-secret`.
+
+> ⚠️ `printf '%s'` (no trailing newline) is important. `echo` appends `\n` and
+> produces an invalid client_secret at request time.
+
+**2.3** Grant the API hub P4SA (per-product service account) read access to the
+secret. The P4SA email format is:
+
+```
+service-<GCP_PROJECT_NUMBER>@gcp-sa-apihub.iam.gserviceaccount.com
+```
+
+Grant `roles/secretmanager.secretAccessor` on the secret:
+
+```bash
+gcloud secrets add-iam-policy-binding <SECRET_NAME> \
+  --member="serviceAccount:service-<GCP_PROJECT_NUMBER>@gcp-sa-apihub.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor" \
+  --project=<GCP_PROJECT_ID>
+```
+
+> If the secret lives in a **different** GCP project than the API hub instance,
+> run the binding in the project where the secret was created — the P4SA email
+> always references the **API hub project's** number.
+
+**2.4** Capture the full secret resource name — you will paste it into the
+plugin instance form in Step 3:
+
+```
+projects/<GCP_PROJECT_ID>/secrets/<SECRET_NAME>/versions/latest
+```
+
+### Step 3: Create the API hub plugin instance
+
+The Function publishes API metadata into a plugin instance of the built-in
+`system-azure-apim` plugin. Create one instance per (Azure subscription, APIM
+service) pair that you plan to sync.
+
+**3.1** In your browser, open API hub in the Cloud console:
+
+```
+https://console.cloud.google.com/apigee/apihub/settings/plugins?project=<GCP_PROJECT_ID>
+```
+
+**3.2** In the **Google Cloud plugins** tab, click **Azure API Management**
+(`system-azure-apim`) → **Create instance**.
+
+**3.3** Fill in the form.
+
+**Details:**
+
+Field        | Value
+------------ | ------------------------
+Display name | Any human-readable label
+
+**Configuration:**
+
+Field                      | Value
+-------------------------- | -------------------------
+**azureTenantId**          | `<AZURE_TENANT_ID>`
+**azureSubscriptionId**    | `<AZURE_SUBSCRIPTION_ID>`
+**azureResourceGroupName** | `<AZURE_RESOURCE_GROUP>`
+**azureApimServiceName**   | `<AZURE_APIM_SERVICE>`
+
+**Authentication:**
+
+Field                                        | Value
+-------------------------------------------- | -----
+**Auth type**                                | **OAuth 2.0 Client Credentials** (required)
+**Client ID**                                | `<AZURE_APP_CLIENT_ID>` from Step 1
+**Client secret** (Secret Manager reference) | `projects/<GCP_PROJECT_ID>/secrets/<SECRET_NAME>/versions/latest` from Step 2.4
+
+**Sync frequency:**
+
+| Field        | Value                                                       |
+| ------------ | ----------------------------------------------------------- |
+| **Schedule** | Runs automatically every **6 hours** by default. Adjust the |
+:              : frequency if you want more or less frequent syncs.          :
+
+**3.4** Click **Create instance** and wait for the status to become **Active**
+(~30 seconds). Note the auto-generated **instance ID** shown on the details page
+— this is `<PLUGIN_INSTANCE_ID>` for Step 6.
+
+> **Initial sync happens automatically.** Once the plugin instance is Active,
+> API hub kicks off a one-time backfill that discovers every existing APIM API
+> in `<AZURE_APIM_SERVICE>` and registers it in API hub. This may take a few
+> minutes depending on the number of APIs. Verify the results in the API hub
+> Console under **APIs**.
+
+**Keeping API hub in sync going forward.** After the initial backfill, you have
+three ways to pick up APIs that are created or updated later:
+
+1.  **Scheduled auto-sync (enabled by default).** The `sync-metadata` action
+    runs every **6 hours** on its own — no action required. Adjust the frequency
+    in the plugin instance's Actions section if you want more or less frequent
+    syncs.
+2.  **On-demand pull from API hub.** In the API hub Console, open the plugin
+    instance and click **Run** to trigger a sync immediately. Useful right after
+    a bulk deployment when you don't want to wait for the next scheduled run.
+3.  **Real-time push from Azure (this sample).** Deploy the Function + Event
+    Grid subscription described in Steps 4–8 below. Azure then pushes individual
+    APIM control-plane events to API hub within ~30–60 seconds of each change.
+
+The three options are complementary — you can enable real-time push later
+without redoing the plugin instance setup.
+
+### Step 4: Create a GCP service account for the Function
+
+At
+`https://console.cloud.google.com/iam-admin/serviceaccounts?project=<GCP_PROJECT_ID>`
+click **+ Create Service Account**.
+
+| Field                | Value                           |
+| -------------------- | ------------------------------- |
+| Service account name | `apihub-azure-onramp-sa`        |
+| Role                 | **Cloud API hub Plugins Admin** |
+:                      : (`roles/apihub.pluginAdmin`)    :
+
+The full SA email will be
+`apihub-azure-onramp-sa@<GCP_PROJECT_ID>.iam.gserviceaccount.com`.
+
+### Step 5: Configure Workload Identity Federation
+
+At
+`https://console.cloud.google.com/iam-admin/workload-identity-pools?project=<GCP_PROJECT_ID>`
+click **Create Pool**.
+
+**5.1 Create pool:**
+
+Field   | Value
+------- | --------------------------
+Name    | `apihub-azure-onramp-pool`
+Enabled | Checked
+
+**5.2 Add provider:**
+
+Field             | Value
+----------------- | ---------------------------------------------
+Provider          | **OpenID Connect (OIDC)**
+Provider name     | `azure-apim-oidc`
+Issuer (URL)      | `https://sts.windows.net/<AZURE_TENANT_ID>/`
+Allowed audiences | `api://<AZURE_APP_CLIENT_ID>` (from Step 1.2)
+
+Leave the "Configure provider attributes" step at its defaults.
+
+**5.3 Grant access** — pick **"Grant access using service account
+impersonation"** (not federated identities), select the `apihub-azure-onramp-sa`
+SA created in Step 4, and add a principal with:
+
+| Attribute name | Attribute value                                           |
+| -------------- | --------------------------------------------------------- |
+| `subject`      | `<AZURE_MI_OBJECT_ID>` (from Step 6 — leave blank for now |
+:                : and add after Bicep deploy)                               :
+
+The grant can be added later without deleting the pool.
+
+**5.4 Build the WIF audience string** (needed in Step 6):
+
+```
+//iam.googleapis.com/projects/<GCP_PROJECT_NUMBER>/locations/global/workloadIdentityPools/apihub-azure-onramp-pool/providers/azure-apim-oidc
+```
+
+### Step 6: Deploy the Bicep template
+
+In Azure Portal → **Deploy a custom template** (search "Deploy a custom
+template" in the top search bar).
+
+-   Click **Build your own template in the editor**.
+-   Delete the placeholder content and paste the contents of `main.bicep` from
+    this directory. The Portal accepts Bicep directly.
+-   Click **Save**.
+-   **Subscription:** `<AZURE_SUBSCRIPTION_ID>`
+-   **Resource group:** `<AZURE_RESOURCE_GROUP>` (the RG holding your APIM)
+-   **Region:** `<AZURE_APIM_REGION>` (must match the APIM region)
+-   **Parameters:**
+
+    | Parameter     | Value                                                    |
+    | ------------- | -------------------------------------------------------- |
+    | apimName      | `<AZURE_APIM_SERVICE>`                                   |
+    | location      | `<AZURE_APIM_REGION>`                                    |
+    | appId         | `<AZURE_APP_CLIENT_ID>` from Step 1                      |
+    | gcpProject    | `<GCP_PROJECT_ID>`                                       |
+    | projectNumber | `<GCP_PROJECT_NUMBER>`                                   |
+    | gcpLocation   | `<GCP_LOCATION>`                                         |
+    | instanceId    | `<PLUGIN_INSTANCE_ID>` from Step 3.4                     |
+    | poolId        | `apihub-azure-onramp-pool` (from Step 5.1 — override if  |
+    :               : you named your WIF pool differently)                     :
+    | providerId    | `azure-apim-oidc` (from Step 5.2 — override if you named |
+    :               : your OIDC provider differently)                          :
+    | saName        | `apihub-azure-onramp-sa` (from Step 4 — override if you  |
+    :               : named your GCP service account differently)              :
+
+    Leave the remaining parameters (`apihubHost`, `pluginId`,
+    `deploymentTypeId`, `apimApiVersion`, `tags`, `enableAppInsights`) at their
+    defaults.
+
+-   Click **Review + create → Create**.
+
+Wait for status **Your deployment is complete** (~2 minutes).
+
+**6.5** After deployment, note the output values on the deployment's **Outputs**
+tab. Copy `uamiPrincipalId` — this is `<AZURE_MI_OBJECT_ID>`.
+
+**6.6** Complete the WIF principal binding you deferred in Step 5.3: go back to
+the Workload Identity Pool, click into the `apihub-azure-onramp-sa` grant, and
+add the principal with `subject` = `<AZURE_MI_OBJECT_ID>`.
+
+**6.7** Also add a **federated credential** to the App Registration from Step 1
+so the Azure Function's managed identity can obtain a token for
+`api://<AZURE_APP_CLIENT_ID>`. Azure Portal → **Entra ID → App registrations →
+apihub-azure-apim → Certificates & secrets → Federated credentials → + Add
+credential**.
+
+| Field            | Value                                              |
+| ---------------- | -------------------------------------------------- |
+| Scenario         | **Managed identity as federated identity**         |
+| Managed identity | Pick the `id-apihub-onramp` user-assigned identity |
+:                  : created by Bicep in Step 6                         :
+| Name             | `apihub-onramp-mi`                                 |
+| Audience         | `api://AzureADTokenExchange` (default)             |
+
+Click **Add**.
+
+### Step 7: Publish the Function code
+
+The Bicep template creates the Function App infrastructure but leaves the
+function code slot empty.
+
+Prerequisites: [Azure Functions Core Tools][func-tools] and the
+[Azure CLI][az-cli] installed. Both are pre-installed in Azure Cloud Shell.
+
+Clone this sample (if you haven't already) and run:
+
+```bash
+git clone https://github.com/GoogleCloudPlatform/apigee-samples.git
+cd apigee-samples/apihub-plugins/azure/apim
+
+az login  # if not already authenticated
+func azure functionapp publish func-apihub-onramp --javascript
+```
+
+Wait for **"Deployment successful"** (~1–2 minutes). The function
+`onrampApimSync` is now live.
+
+[func-tools]: https://learn.microsoft.com/azure/azure-functions/functions-run-local
+[az-cli]: https://learn.microsoft.com/cli/azure/install-azure-cli
+
+### Step 8: Create the Event Grid subscription
+
+Azure Portal → open the **APIM service** `<AZURE_APIM_SERVICE>` → left nav →
+**Events → + Event Subscription**.
+
+| Field                 | Value                                 |
+| --------------------- | ------------------------------------- |
+| Name                  | `apihub-onramp-sync`                  |
+| Event Schema          | **Event Grid Schema**                 |
+| Filter to Event Types | Uncheck all except                    |
+:                       : `Microsoft.ApiManagement.APICreated`, :
+:                       : `Microsoft.ApiManagement.APIUpdated`, :
+:                       : `Microsoft.ApiManagement.APIDeleted`  :
+| Endpoint Type         | **Azure Function**                    |
+| Endpoint              | Click **Select an endpoint** → pick   |
+:                       : the `func-apihub-onramp` Function App :
+:                       : → function `onrampApimSync`           :
+
+Click **Create**. Wait ~30 seconds for provisioning.
+
+### Step 9: Verify
+
+Create or edit any API in your APIM instance (APIM Portal → **APIs → + Add API →
+HTTP** or **OpenAPI**). Within 30–60 seconds:
+
+-   The Function invocation appears in **Function App → Functions →
+    onrampApimSync → Monitor** with `Success` status.
+-   The API shows up in API hub at
+    `https://console.cloud.google.com/apigee/apihub?project=<GCP_PROJECT_ID>`
+    with the APIM subscription/service/api path as its `original_id`.
+
+If the invocation fails, check the **Result** field on the Monitor page for the
+exception message. Common causes:
+
+-   WIF principal binding missing on the SA (revisit Step 6.6 with the
+    `<AZURE_MI_OBJECT_ID>` from Step 6.5).
+-   Federated credential missing on the App Registration (revisit Step 6.7).
+-   IAM Credentials API not enabled (`gcloud services enable
+    iamcredentials.googleapis.com --project=<GCP_PROJECT_ID>`).
+-   Service account missing `roles/apihub.pluginAdmin` on the API hub project
+    (revisit Step 4).
+
+## Files Included
+
+-   `main.bicep`: Azure infrastructure template (Function App + storage + App
+    Service plan + user-assigned managed identity + APIM Reader role
+    assignment + optional Application Insights).
+-   `src/functions/onrampApimSync.js`: The Event Grid-triggered sync function
+    (Node.js 20).
+-   `host.json`, `package.json`: Azure Functions runtime configuration.
+
+## Disclaimer
+
+This is a sample integration and may require modifications to fit your specific
+security and operational requirements.

--- a/apihub-plugins/azure/apim/README.md
+++ b/apihub-plugins/azure/apim/README.md
@@ -39,6 +39,15 @@ credentials are stored in Azure.
     holding the APIM (to deploy resources), plus `User Access Administrator` (to
     assign the APIM `Reader` role), and `Application Administrator` at the Entra
     tenant level (to create the App Registration).
+5.  **Azure subscription tier:** a **Pay-As-You-Go** or other paid subscription.
+    **Free / Trial subscriptions cannot deploy this sample** — they ship with
+    `0` quota for the Consumption Plan (Y1) SKU that the Function App in
+    [Step 6](#step-6-deploy-the-bicep-template) requires, and the deploy fails
+    preflight with `SubscriptionIsOverQuotaForSku`. Upgrade via **Subscriptions
+    → your subscription → Overview → Upgrade** before starting; Pay-As-You-Go
+    grants the default Y1 quota automatically. If the upgrade does not raise the
+    Y1 limit for your region, see [Step 6.0](#step-6-deploy-the-bicep-template)
+    for how to request it explicitly.
 
 ## Values to gather before starting
 
@@ -83,7 +92,11 @@ Redirect URI            | Leave blank
 Click **Register**.
 
 **1.2** On the app's **Overview** page, copy the **Application (client) ID** —
-this is `<AZURE_APP_CLIENT_ID>`.
+this is `<AZURE_APP_CLIENT_ID>`. Then set an **Application ID URI**: on the same
+Overview page, click **Add an Application ID URI → Set**, keep the default value
+`api://<AZURE_APP_CLIENT_ID>`, and **Save**. Without this URI Microsoft Entra
+will refuse to issue tokens with that audience, and the Function fails silently
+at `AADSTS500011` when it tries to fetch a subject token for WIF.
 
 **1.3** In the left nav → **Certificates & secrets → + New client secret**.
 
@@ -120,10 +133,18 @@ The API hub plugin instance reads `<AZURE_APP_CLIENT_SECRET>` from a Secret
 Manager secret. The application id is not sensitive and goes directly on the
 plugin instance form.
 
-**2.1** Enable the Secret Manager API (skip if it's already enabled):
+**2.1** Enable the Secret Manager, IAM Credentials, and Security Token Service
+APIs (skip whichever are already enabled). All three are required — Secret
+Manager holds the Azure client secret, and IAM Credentials + STS are used by the
+real-time push in Steps 4-9 for the Workload Identity Federation token exchange.
+Missing IAM Credentials or STS surfaces later as an `impersonation HTTP 403`
+from the Function:
 
 ```bash
-gcloud services enable secretmanager.googleapis.com \
+gcloud services enable \
+    secretmanager.googleapis.com \
+    iamcredentials.googleapis.com \
+    sts.googleapis.com \
   --project=<GCP_PROJECT_ID>
 ```
 
@@ -169,7 +190,7 @@ gcloud secrets add-iam-policy-binding <SECRET_NAME> \
 plugin instance form in Step 3:
 
 ```
-projects/<GCP_PROJECT_ID>/secrets/<SECRET_NAME>/versions/latest
+projects/<GCP_PROJECT_ID>/secrets/<SECRET_NAME>/versions/<VERSION_NUMBER>
 ```
 
 ### Step 3: Create the API hub plugin instance
@@ -210,7 +231,7 @@ Field                                        | Value
 -------------------------------------------- | -----
 **Auth type**                                | **OAuth 2.0 Client Credentials** (required)
 **Client ID**                                | `<AZURE_APP_CLIENT_ID>` from Step 1
-**Client secret** (Secret Manager reference) | `projects/<GCP_PROJECT_ID>/secrets/<SECRET_NAME>/versions/latest` from Step 2.4
+**Client secret** (Secret Manager reference) | `projects/<GCP_PROJECT_ID>/secrets/<SECRET_NAME>/versions/<VERSION_NUMBER>` from Step 2.4
 
 **Sync frequency:**
 
@@ -283,7 +304,10 @@ Provider name     | `azure-apim-oidc`
 Issuer (URL)      | `https://sts.windows.net/<AZURE_TENANT_ID>/`
 Allowed audiences | `api://<AZURE_APP_CLIENT_ID>` (from Step 1.2)
 
-Leave the "Configure provider attributes" step at its defaults.
+Under **Configure provider attributes**, verify that `google.subject` is mapped
+to `assertion.sub`. The default should already show this, but the Console
+occasionally clears the field and rejects the pool at Save with `attribute
+mapping is required`; if the input is empty, type `assertion.sub` manually.
 
 **5.3 Grant access** — pick **"Grant access using service account
 impersonation"** (not federated identities), select the `apihub-azure-onramp-sa`
@@ -304,50 +328,78 @@ The grant can be added later without deleting the pool.
 
 ### Step 6: Deploy the Bicep template
 
-In Azure Portal → **Deploy a custom template** (search "Deploy a custom
-template" in the top search bar).
+Deploy via **Azure Cloud Shell** (browser-based; no local tooling required). The
+Portal's "Build your own template in the editor" pane accepts only ARM JSON, but
+`az deployment` in Cloud Shell transpiles Bicep on the fly when you pass a
+`.bicep` file directly.
 
--   Click **Build your own template in the editor**.
--   Delete the placeholder content and paste the contents of `main.bicep` from
-    this directory. The Portal accepts Bicep directly.
--   Click **Save**.
--   **Subscription:** `<AZURE_SUBSCRIPTION_ID>`
--   **Resource group:** `<AZURE_RESOURCE_GROUP>` (the RG holding your APIM)
--   **Region:** `<AZURE_APIM_REGION>` (must match the APIM region)
--   **Parameters:**
+> If the deploy fails with `SubscriptionIsOverQuotaForSku: Current Limit (Y1
+> VMs): 0`, you are on a Free / Trial subscription. Upgrade to Pay-As-You-Go per
+> [Prerequisites](#prerequisites) item 5 and re-run — the upgrade grants Y1
+> quota automatically in most tenants. If it does not, follow Step 6.0 below.
 
-    | Parameter     | Value                                                    |
-    | ------------- | -------------------------------------------------------- |
-    | apimName      | `<AZURE_APIM_SERVICE>`                                   |
-    | location      | `<AZURE_APIM_REGION>`                                    |
-    | appId         | `<AZURE_APP_CLIENT_ID>` from Step 1                      |
-    | gcpProject    | `<GCP_PROJECT_ID>`                                       |
-    | projectNumber | `<GCP_PROJECT_NUMBER>`                                   |
-    | gcpLocation   | `<GCP_LOCATION>`                                         |
-    | instanceId    | `<PLUGIN_INSTANCE_ID>` from Step 3.4                     |
-    | poolId        | `apihub-azure-onramp-pool` (from Step 5.1 — override if  |
-    :               : you named your WIF pool differently)                     :
-    | providerId    | `azure-apim-oidc` (from Step 5.2 — override if you named |
-    :               : your OIDC provider differently)                          :
-    | saName        | `apihub-azure-onramp-sa` (from Step 4 — override if you  |
-    :               : named your GCP service account differently)              :
+**6.0** (Only if the subscription upgrade did not grant Y1 quota in your
+region.) Request Y1 quota explicitly: in the Azure Portal, search for
+**Quotas**, select **App Service** (older tenants list it under **Compute**),
+filter by **Provider = Microsoft.Web** and **Region = `<AZURE_APIM_REGION>`**,
+find **Dynamic App Service Plans**, tick the row, and submit **New Quota
+Request** for `1` (or higher for headroom). Small requests typically resolve in
+a few hours; worst case ~1 business day.
 
-    Leave the remaining parameters (`apihubHost`, `pluginId`,
-    `deploymentTypeId`, `apimApiVersion`, `tags`, `enableAppInsights`) at their
-    defaults.
+**6.1** In the Azure Portal, click the Cloud Shell icon (`>_`) in the top nav
+bar and pick **Bash**. On first use, accept the default when prompted to create
+a Cloud Shell storage account.
 
--   Click **Review + create → Create**.
+**6.2** In Cloud Shell, run `code main.bicep`. A VS Code-style editor opens in
+the upper pane. Paste the contents of `main.bicep` from this directory, save
+with **Ctrl+S**, then close with **Ctrl+Q**.
 
-Wait for status **Your deployment is complete** (~2 minutes).
+**6.3** Deploy.
 
-**6.5** After deployment, note the output values on the deployment's **Outputs**
+> ⚠️ Cloud Shell defaults to **PowerShell** on returning sessions, and the
+> multi-line ``\` continuations below are Bash syntax — pasting them into
+> a``PS>`prompt fails with`ParserError: Missing expression after unary operator
+> '-'`. If your prompt is `PS>`, type `bash`and press Enter to switch; the
+> prompt should become`$`(or`user@Azure:~$`).
+
+```bash
+az deployment group create \
+  --resource-group <AZURE_RESOURCE_GROUP> \
+  --template-file main.bicep \
+  --parameters \
+      apimName=<AZURE_APIM_SERVICE> \
+      location=<AZURE_APIM_REGION> \
+      appId=<AZURE_APP_CLIENT_ID> \
+      gcpProject=<GCP_PROJECT_ID> \
+      projectNumber=<GCP_PROJECT_NUMBER> \
+      gcpLocation=<GCP_LOCATION> \
+      instanceId=<PLUGIN_INSTANCE_ID>
+```
+
+Override `poolId`, `providerId`, or `saName` only if you named those resources
+differently in Steps 4-5 (defaults: `apihub-azure-onramp-pool`,
+`azure-apim-oidc`, `apihub-azure-onramp-sa`). Leave `apihubHost`, `pluginId`,
+`deploymentTypeId`, `apimApiVersion`, `tags`, and `enableAppInsights` at their
+defaults.
+
+Wait for the CLI to print `"provisioningState": "Succeeded"` (~2 minutes). The
+deployment is also visible in the Portal under the resource group's
+**Deployments** blade.
+
+> If Cloud Shell is unavailable in your tenant, transpile the Bicep to ARM JSON
+> on a workstation with Azure CLI installed (`az bicep build --file main.bicep`
+> emits `main.json`), then in the Portal use **Deploy a custom template → Build
+> your own template in the editor → Load file** and pick `main.json`. Fill the
+> parameters listed above via the Portal form.
+
+**6.4** After deployment, note the output values on the deployment's **Outputs**
 tab. Copy `uamiPrincipalId` — this is `<AZURE_MI_OBJECT_ID>`.
 
-**6.6** Complete the WIF principal binding you deferred in Step 5.3: go back to
+**6.5** Complete the WIF principal binding you deferred in Step 5.3: go back to
 the Workload Identity Pool, click into the `apihub-azure-onramp-sa` grant, and
 add the principal with `subject` = `<AZURE_MI_OBJECT_ID>`.
 
-**6.7** Also add a **federated credential** to the App Registration from Step 1
+**6.6** Also add a **federated credential** to the App Registration from Step 1
 so the Azure Function's managed identity can obtain a token for
 `api://<AZURE_APP_CLIENT_ID>`. Azure Portal → **Entra ID → App registrations →
 apihub-azure-apim → Certificates & secrets → Federated credentials → + Add
@@ -371,14 +423,37 @@ function code slot empty.
 Prerequisites: [Azure Functions Core Tools][func-tools] and the
 [Azure CLI][az-cli] installed. Both are pre-installed in Azure Cloud Shell.
 
-Clone this sample (if you haven't already) and run:
+The Function App name is `func-apihub-onramp-<hash>`, where `<hash>` is a
+6-character suffix derived from the resource group ID (so the name is globally
+unique — Function Apps become `*.azurewebsites.net` DNS entries). Grab the exact
+name from the Bicep output — read it directly from Step 6.4's outputs tab
+(`functionAppName`), or from Cloud Shell:
+
+```bash
+FUNC=$(az deployment group show \
+  --resource-group <AZURE_RESOURCE_GROUP> --name main \
+  --query "properties.outputs.functionAppName.value" -o tsv)
+echo "$FUNC"
+```
+
+Clone this sample (if you haven't already), install the Node dependencies from
+`package.json`, and publish.
+
+> ⚠️ **Do not skip `npm install`.** `func … publish` uploads the local project
+> directory as-is and does not install dependencies on the server. Publishing
+> without `node_modules/` leaves `onrampApimSync` failing at import — and
+> because Event Grid probes the endpoint during subscription creation with a
+> handshake POST, **Step 8 fails with a `webhookNotification` / webhook
+> validation error** rather than at first invocation. Always run `npm install`
+> in the same directory as `package.json` before `func … publish`.
 
 ```bash
 git clone https://github.com/GoogleCloudPlatform/apigee-samples.git
 cd apigee-samples/apihub-plugins/azure/apim
 
-az login  # if not already authenticated
-func azure functionapp publish func-apihub-onramp --javascript
+az login       # if not already authenticated
+npm install    # installs dependencies declared in package.json into node_modules/
+func azure functionapp publish "$FUNC" --javascript
 ```
 
 Wait for **"Deployment successful"** (~1–2 minutes). The function
@@ -389,8 +464,26 @@ Wait for **"Deployment successful"** (~1–2 minutes). The function
 
 ### Step 8: Create the Event Grid subscription
 
-Azure Portal → open the **APIM service** `<AZURE_APIM_SERVICE>` → left nav →
-**Events → + Event Subscription**.
+**8.1** Enable the APIM instance's **system-assigned managed identity** — API
+Management uses this identity to authenticate to Event Grid when publishing
+control-plane events, and Event Subscription creation fails without it. This is
+a Microsoft-documented prerequisite ([reference][apim-eg]).
+
+Either from the Portal — open the APIM service `<AZURE_APIM_SERVICE>` → left nav
+**Security → Managed identities** → **System assigned** tab → toggle **Status =
+On** → **Save** — or from Cloud Shell:
+
+```bash
+az apim update \
+  --name <AZURE_APIM_SERVICE> \
+  --resource-group <AZURE_RESOURCE_GROUP> \
+  --set identity.type="SystemAssigned"
+```
+
+Wait ~30 seconds for the identity to provision.
+
+**8.2** Create the Event Grid subscription. Azure Portal → APIM service
+`<AZURE_APIM_SERVICE>` → left nav → **Events → + Event Subscription**.
 
 | Field                 | Value                                 |
 | --------------------- | ------------------------------------- |
@@ -402,10 +495,14 @@ Azure Portal → open the **APIM service** `<AZURE_APIM_SERVICE>` → left nav �
 :                       : `Microsoft.ApiManagement.APIDeleted`  :
 | Endpoint Type         | **Azure Function**                    |
 | Endpoint              | Click **Select an endpoint** → pick   |
-:                       : the `func-apihub-onramp` Function App :
-:                       : → function `onrampApimSync`           :
+:                       : the `func-apihub-onramp-<hash>`       :
+:                       : Function App (from Step 6.4 output    :
+:                       : `functionAppName`) → function         :
+:                       : `onrampApimSync`                      :
 
 Click **Create**. Wait ~30 seconds for provisioning.
+
+[apim-eg]: https://learn.microsoft.com/en-us/azure/api-management/how-to-event-grid
 
 ### Step 9: Verify
 
@@ -421,13 +518,31 @@ HTTP** or **OpenAPI**). Within 30–60 seconds:
 If the invocation fails, check the **Result** field on the Monitor page for the
 exception message. Common causes:
 
--   WIF principal binding missing on the SA (revisit Step 6.6 with the
-    `<AZURE_MI_OBJECT_ID>` from Step 6.5).
--   Federated credential missing on the App Registration (revisit Step 6.7).
+-   WIF principal binding missing on the SA (revisit Step 6.5 with the
+    `<AZURE_MI_OBJECT_ID>` from Step 6.4).
+-   Federated credential missing on the App Registration (revisit Step 6.6).
 -   IAM Credentials API not enabled (`gcloud services enable
     iamcredentials.googleapis.com --project=<GCP_PROJECT_ID>`).
 -   Service account missing `roles/apihub.pluginAdmin` on the API hub project
     (revisit Step 4).
+-   **VPC Service Controls violation (`HTTP 403`, `type: VPC_SERVICE_CONTROLS`,
+    `reason: SECURITY_POLICY_VIOLATED`).** If the API hub project sits in a VPC
+    Service Perimeter, `iamcredentials.googleapis.com` and
+    `apihub.googleapis.com` are usually in its restricted-services list, so the
+    Function's WIF impersonation call and the subsequent `CollectApiData` are
+    both denied. Fix: add a perimeter **ingress rule** that permits the Azure
+    caller. Grab the `vpcServiceControlsUniqueIdentifier` from the exception,
+    paste it into Cloud Console → **Security → VPC Service Controls →
+    Troubleshoot** to identify the perimeter, then add an ingress rule with
+    **identities** = the WIF principal
+    (`principal://iam.googleapis.com/projects/<GCP_PROJECT_NUMBER>/locations/global/workloadIdentityPools/apihub-azure-onramp-pool/subject/<AZURE_MI_OBJECT_ID>`)
+    **and** the impersonated SA
+    (`serviceAccount:apihub-azure-onramp-sa@<GCP_PROJECT_ID>.iam.gserviceaccount.com`);
+    **source** = `accessLevel: '*'` (any); **target operations** =
+    `iamcredentials.googleapis.com` and `apihub.googleapis.com`. Both identities
+    are needed in one rule because impersonation is called by the federated
+    principal, and the subsequent `CollectApiData` is called by the impersonated
+    SA.
 
 ## Files Included
 

--- a/apihub-plugins/azure/apim/host.json
+++ b/apihub-plugins/azure/apim/host.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/apihub-plugins/azure/apim/main.bicep
+++ b/apihub-plugins/azure/apim/main.bicep
@@ -1,0 +1,142 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Azure infra for the real-time Azure APIM -> API hub on-ramp.
+// Graph-free: App Registration is created manually in the Azure Portal
+// (README Step 1) and its Application (client) id is passed here as `appId`.
+// Idempotent by nature (re-deploy converges; no "already exists" errors).
+
+targetScope = 'resourceGroup'
+
+@description('Name of the EXISTING APIM service in this resource group')
+param apimName string
+@description('Region for created resources (azure_setup.sh passes the APIM region)')
+param location string
+@description('App (client) ID of the pre-created App Registration = WIF audience')
+param appId string
+@description('Tags applied to all created resources')
+param tags object = {}
+@description('Optional: create Application Insights + Log Analytics for function logs')
+param enableAppInsights bool = false
+
+param gcpProject string
+param projectNumber string
+param gcpLocation string
+param instanceId string
+param poolId string = 'apihub-azure-onramp-pool'
+param providerId string = 'azure-apim-oidc'
+param saName string = 'apihub-azure-onramp-sa'
+param apihubHost string = 'https://apihub.googleapis.com'
+param pluginId string = 'system-azure-apim'
+param deploymentTypeId string = 'azure-apim'
+param apimApiVersion string = '2024-05-01'
+
+resource apim 'Microsoft.ApiManagement/service@2023-05-01-preview' existing = { name: apimName }
+
+var sfx       = uniqueString(resourceGroup().id)
+var funcName  = 'func-apihub-onramp'
+var planName  = 'plan-apihub-onramp'
+var uamiName  = 'id-apihub-onramp'
+var lawName   = 'law-apihub-onramp'
+var appiName  = 'appi-apihub-onramp'
+var storageNm = toLower('stapihubonramp${substring(sfx, 0, 6)}')
+var wifAud    = '//iam.googleapis.com/projects/${projectNumber}/locations/global/workloadIdentityPools/${poolId}/providers/${providerId}'
+var saEmail   = '${saName}@${gcpProject}.iam.gserviceaccount.com'
+
+resource uami 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: uamiName
+  location: location
+  tags: tags
+}
+
+// ---- Optional Application Insights (workspace-based) for function logs ----
+resource law 'Microsoft.OperationalInsights/workspaces@2023-09-01' = if (enableAppInsights) {
+  name: lawName
+  location: location
+  tags: tags
+  properties: { sku: { name: 'PerGB2018' }, retentionInDays: 30 }
+}
+resource appi 'Microsoft.Insights/components@2020-02-02' = if (enableAppInsights) {
+  name: appiName
+  location: location
+  kind: 'web'
+  tags: tags
+  properties: { Application_Type: 'web', WorkspaceResourceId: law.id }
+}
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageNm
+  location: location
+  tags: tags
+  sku: { name: 'Standard_LRS' }
+  kind: 'StorageV2'
+  properties: { minimumTlsVersion: 'TLS1_2', allowBlobPublicAccess: false }
+}
+resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: planName
+  location: location
+  tags: tags
+  sku: { name: 'Y1', tier: 'Dynamic' }
+  kind: 'functionapp'
+  properties: { reserved: true }
+}
+resource func 'Microsoft.Web/sites@2023-12-01' = {
+  name: funcName
+  location: location
+  tags: tags
+  kind: 'functionapp,linux'
+  identity: { type: 'UserAssigned', userAssignedIdentities: { '${uami.id}': {} } }
+  properties: {
+    serverFarmId: plan.id
+    httpsOnly: true
+    siteConfig: {
+      linuxFxVersion: 'Node|20'
+      appSettings: concat([
+        { name: 'AzureWebJobsStorage', value: 'DefaultEndpointsProtocol=https;AccountName=${storage.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storage.listKeys().keys[0].value}' }
+        { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
+        { name: 'FUNCTIONS_WORKER_RUNTIME', value: 'node' }
+        { name: 'AZURE_CLIENT_ID', value: uami.properties.clientId }
+        { name: 'AZURE_TENANT_ID', value: tenant().tenantId }
+        { name: 'WIF_APP_ID_URI', value: 'api://${appId}' }
+        { name: 'WIF_AUDIENCE', value: wifAud }
+        { name: 'WIF_SA_EMAIL', value: saEmail }
+        { name: 'PROJECT', value: gcpProject }
+        { name: 'LOCATION', value: gcpLocation }
+        { name: 'APIHUB_HOST', value: apihubHost }
+        { name: 'INSTANCE_ID', value: instanceId }
+        { name: 'PLUGIN_ID', value: pluginId }
+        { name: 'DEPLOYMENT_TYPE_ID', value: deploymentTypeId }
+        { name: 'APIM_API_VERSION', value: apimApiVersion }
+      ], enableAppInsights ? [
+        { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appi.properties.ConnectionString }
+      ] : [])
+    }
+  }
+}
+
+// ---- Reader on the existing APIM for the function's identity ----
+var readerRole = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+resource reader 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(apim.id, uami.id, readerRole)
+  scope: apim
+  properties: {
+    roleDefinitionId: readerRole
+    principalId: uami.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output uamiPrincipalId string = uami.properties.principalId
+output functionAppName string  = func.name
+output wifAudience string       = wifAud

--- a/apihub-plugins/azure/apim/main.bicep
+++ b/apihub-plugins/azure/apim/main.bicep
@@ -45,7 +45,10 @@ param apimApiVersion string = '2024-05-01'
 resource apim 'Microsoft.ApiManagement/service@2023-05-01-preview' existing = { name: apimName }
 
 var sfx       = uniqueString(resourceGroup().id)
-var funcName  = 'func-apihub-onramp'
+// Function App names become <name>.azurewebsites.net and must be globally
+// unique across all of Azure, so a per-RG suffix is appended. The remaining
+// names are RG-scoped and stay stable so operators can locate them by name.
+var funcName  = 'func-apihub-onramp-${substring(sfx, 0, 6)}'
 var planName  = 'plan-apihub-onramp'
 var uamiName  = 'id-apihub-onramp'
 var lawName   = 'law-apihub-onramp'

--- a/apihub-plugins/azure/apim/package.json
+++ b/apihub-plugins/azure/apim/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "apihub-azure-apim-onramp",
+  "version": "1.0.0",
+  "main": "src/functions/*.js",
+  "dependencies": {
+    "@azure/functions": "^4.5.0"
+  }
+}

--- a/apihub-plugins/azure/apim/src/functions/onrampApimSync.js
+++ b/apihub-plugins/azure/apim/src/functions/onrampApimSync.js
@@ -1,0 +1,907 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {app} = require('@azure/functions');
+
+// =============================================================================
+// Azure APIM -> API hub event-driven push (Event Grid).
+//
+// This forwards real-time APIM API events to API hub collectApiData so a change
+// is reflected immediately, ahead of the periodic pull sync. It is aligned with
+// the pull engine's mapping so a push UPSERTs the SAME resources the pull
+// writes (identical original_ids, display names, attributes, api-style,
+// deployment-type, spec kinds and endpoints) instead of creating duplicates.
+// =============================================================================
+
+// ---- env --------------------------------------------------------------
+const APIHUB_HOST = process.env.APIHUB_HOST;  // https://apihub.googleapis.com
+const PROJECT = process.env.PROJECT;          // API hub host project id
+const LOCATION = process.env.LOCATION;        // e.g. europe-west1
+const INSTANCE_ID =
+    process.env.INSTANCE_ID;  // REQUIRED - system-azure-apim plugin instance id
+const WIF_AUDIENCE =
+    process.env
+        .WIF_AUDIENCE;  // //iam.googleapis.com/projects/<PN>/locations/global/workloadIdentityPools/<POOL>/providers/<PROVIDER>
+const WIF_SA_EMAIL =
+    process.env.WIF_SA_EMAIL;  // <sa>@<project>.iam.gserviceaccount.com
+const WIF_APP_ID_URI =
+    process.env.WIF_APP_ID_URI;  // api://<APP_ID>  (Azure app registration
+                                 // Application ID URI)
+const AZURE_TENANT_ID = process.env.AZURE_TENANT_ID;  // Azure tenant GUID
+const AZURE_CLIENT_ID =
+    process.env.AZURE_CLIENT_ID;  // leave UNSET for system-assigned MI
+
+// Registered API hub plugin id. MUST match your plugin instance resource name:
+// projects/.../plugins/<PLUGIN_ID>/instances/<INSTANCE_ID>.
+const PLUGIN_ID = process.env.PLUGIN_ID || 'system-azure-apim';
+
+// Registered system-deployment-type allowed value. Keep this in sync with the
+// pull engine so push and pull write the same deployment type.
+const DEPLOYMENT_TYPE_ID = process.env.DEPLOYMENT_TYPE_ID || 'azure-apim';
+
+// GCP identity endpoints (defaults are prod; override via app settings for
+// other environments).
+const STS_URL = process.env.STS_URL || 'https://sts.googleapis.com/v1/token';
+const IAM_CRED_HOST =
+    process.env.IAM_CRED_HOST || 'https://iamcredentials.googleapis.com';
+// Azure platform-injected MI endpoint (Functions; NOT 169.254.169.254).
+const IDENTITY_ENDPOINT = process.env.IDENTITY_ENDPOINT;
+const IDENTITY_HEADER = process.env.IDENTITY_HEADER;
+
+const ARM_RESOURCE = 'https://management.azure.com';
+// 2024-05-01 covers the six typed API types. A2A (type "a2a" / a2aProperties)
+// is NOT modeled there -- to detect A2A, set APIM_API_VERSION to a version that
+// returns those raw fields (a 2024-06+ preview; confirm with
+// testing_spec/a2atest).
+const APIM_API_VERSION = process.env.APIM_API_VERSION || '2024-05-01';
+const COLLECT_URL = `${APIHUB_HOST}/v1/projects/${PROJECT}/locations/${
+    LOCATION}:collectApiData`;
+const PLUGIN_INSTANCE = `projects/${PROJECT}/locations/${LOCATION}/plugins/${
+    PLUGIN_ID}/instances/${INSTANCE_ID}`;
+const ACTION_ID = 'sync-metadata';
+
+// =============================================================================
+// AUTH SECTION - UNCHANGED (Azure MI token + GCP WIF exchange). Do not edit.
+// =============================================================================
+
+// ---- WIF diagnostic: decode (do NOT log the raw token) ----------------
+function decodeJwtClaims(jwt) {
+  try {
+    const c =
+        JSON.parse(Buffer.from(jwt.split('.')[1], 'base64').toString('utf8'));
+    return {
+      iss: c.iss,
+      aud: c.aud,
+      sub: c.sub,
+      oid: c.oid,
+      appid: c.appid,
+      ver: c.ver,
+      tid: c.tid
+    };
+  } catch (e) {
+    return {decodeError: e.message};
+  }
+}
+
+// ---- Azure MI token ---------------------------------------------------
+async function getAzureToken(resource) {
+  if (!IDENTITY_ENDPOINT || !IDENTITY_HEADER)
+    throw new Error(
+        'MI endpoint missing - is system-assigned identity enabled on the Function?');
+  const u = new URL(IDENTITY_ENDPOINT);
+  u.searchParams.set('resource', resource);
+  u.searchParams.set('api-version', '2019-08-01');
+  if (AZURE_CLIENT_ID) u.searchParams.set('client_id', AZURE_CLIENT_ID);
+  const r = await fetch(u, {headers: {'X-IDENTITY-HEADER': IDENTITY_HEADER}});
+  if (!r.ok) throw new Error(`MI token HTTP ${r.status}: ${await r.text()}`);
+  const d = await r.json();
+  if (!d.access_token)
+    throw new Error('MI token response missing access_token');
+  return d.access_token;
+}
+
+// ---- GCP WIF chain ----------------------------------------------------
+let cachedToken = null, cachedExp = 0;
+async function fetchApiHubToken() {
+  const now = Math.floor(Date.now() / 1000);
+  if (cachedToken && cachedExp - now > 300) return cachedToken;
+  // ---- fail fast on misconfiguration (clear errors instead of opaque 400s)
+  // ----
+  if (!WIF_AUDIENCE || !WIF_AUDIENCE.startsWith('//iam.googleapis.com/'))
+    throw new Error(
+        `WIF_AUDIENCE missing/malformed (must start with //iam.googleapis.com/). Got: [${
+            WIF_AUDIENCE}]`);
+  if (!WIF_APP_ID_URI)
+    throw new Error('WIF_APP_ID_URI not set (expected api://<APP_ID>).');
+  if (!WIF_SA_EMAIL) throw new Error('WIF_SA_EMAIL not set.');
+  if (!INSTANCE_ID)
+    throw new Error(
+        'INSTANCE_ID not set - plugin_instance is REQUIRED by collectApiData.');
+  const subjectToken = await getAzureToken(WIF_APP_ID_URI);
+  // ---- WIF DIAGNOSTICS (remove once working) ----
+  console.log(
+      'AZURE_TOKEN_CLAIMS ' + JSON.stringify(decodeJwtClaims(subjectToken)));
+  console.log(
+      'STS_AUDIENCE_SENT [' + WIF_AUDIENCE +
+      '] len=' + (WIF_AUDIENCE || '').length);
+  console.log('STS_ENDPOINT ' + STS_URL);
+  console.log('PLUGIN_INSTANCE ' + PLUGIN_INSTANCE);
+  // ------------------------------------------------
+  const stsBody = new URLSearchParams({
+    audience: WIF_AUDIENCE,
+    grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+    requested_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+    scope: 'https://www.googleapis.com/auth/cloud-platform',
+    subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+    subject_token: subjectToken,
+  });
+  const sts = await fetch(STS_URL, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    body: stsBody,
+  });
+  if (!sts.ok) throw new Error(`STS HTTP ${sts.status}: ${await sts.text()}`);
+  const fed = (await sts.json()).access_token;
+  const imp = await fetch(
+      `${IAM_CRED_HOST}/v1/projects/-/serviceAccounts/${
+          encodeURIComponent(WIF_SA_EMAIL)}:generateAccessToken`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${fed}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          scope: ['https://www.googleapis.com/auth/cloud-platform'],
+          lifetime: '3600s'
+        })
+      });
+  if (!imp.ok)
+    throw new Error(`impersonation HTTP ${imp.status}: ${await imp.text()}`);
+  const j = await imp.json();
+  cachedToken = j.accessToken;
+  cachedExp = Math.floor(new Date(j.expireTime).getTime() / 1000);
+  return cachedToken;
+}
+
+// =============================================================================
+// END AUTH SECTION.
+// =============================================================================
+
+const nowIso = () => new Date().toISOString();
+
+// ---- API hub attribute ids (azure.go) ---------------------------------
+const ATTR_PRODUCTS = 'plugin-azure-apim-products';
+const ATTR_TAGS = 'plugin-azure-apim-api-tags';
+const ATTR_REVISION = 'plugin-azure-apim-revision';
+const ATTR_SUBSCRIPTION_REQUIRED = 'plugin-azure-apim-subscription-required';
+const ATTR_GATEWAY = 'plugin-azure-apim-gateway';
+const SYSTEM_DEPLOYMENT_TYPE_ATTR =
+    'system-deployment-type';       // datarepo.SystemDeploymentType
+const GATEWAY_MANAGED = 'managed';  // azureGatewayManaged
+const SYNTHETIC_VERSION_ID = 'v1';  // azureSyntheticVersionID
+
+// ---- API-style allowed values (datarepo constants) --------------------
+const API_STYLE = {
+  http: 'rest',  // RESTSystemAPIStyleImmutableAllowedValueID
+  soap: 'soap',
+  graphql: 'graphql',
+  grpc: 'grpc',
+  websocket: 'websocket',
+  odata: 'odata',
+  a2a: 'a2a',  // agentic; arrives only via this event path (see
+               // classifyAzureApiType)
+};
+
+// ---- resource-name formatters (core_service/shared/utils/formatter.go) -
+const locationResourceName = () => `projects/${PROJECT}/locations/${LOCATION}`;
+const apisResourceName = (apiId) => `${locationResourceName()}/apis/${apiId}`;
+const attributeResourceName = (attrId) =>
+    `${locationResourceName()}/attributes/${attrId}`;
+
+// ---- identifier parity helpers (grouping.go / clients.go) --------------
+// azureBaseAPIID: strip APIM's ";rev=N" suffix (grouping.go). Do NOT lowercase:
+// the pull path keys resources by the apiId/serviceName as-is.
+const azureBaseAPIID = (id) => {
+  const i = (id || '').indexOf(';rev=');
+  return i >= 0 ? id.slice(0, i) : id;
+};
+
+// azureLastSegment: final path segment of an ARM resource id (clients.go).
+const azureLastSegment = (s) => {
+  s = (s || '').replace(/^\/+|\/+$/g, '');
+  const i = s.lastIndexOf('/');
+  return i >= 0 ? s.slice(i + 1) : s;
+};
+
+// azureResourceURI: the shared original_id prefix and deployment resource_uri
+// (mapping.go:azureResourceURI). serviceName + apiId are used as-is.
+const azureResourceURI = (scope, apiId) =>
+    `subscriptions/${scope.subscriptionId}/resourceGroups/${
+        scope.resourceGroup}` +
+    `/service/${scope.serviceName}/apis/${apiId}`;
+
+// azureManagementURL: Azure portal deep link to the APIM APIs blade
+// (mapping.go).
+const azureManagementURL = (scope) =>
+    `https://portal.azure.com/#@${AZURE_TENANT_ID}/resource/subscriptions/${
+        scope.subscriptionId}` +
+    `/resourceGroups/${
+        scope.resourceGroup}/providers/Microsoft.ApiManagement/service/${
+        scope.serviceName}/apim-apis`;
+
+// azureGroupKeyAndDisplay: one event's API mapped to its version-set group
+// (grouping.go:groupAzureAPIs + azureGroupDisplayName). The logical API hub Api
+// is keyed by the version-set short id (so all versions converge on one Api),
+// or the base apiId when unversioned.
+function azureGroupKeyAndDisplay(api) {
+  const key = api.versionSetId || azureBaseAPIID(api.id);
+  const displayName = (api.versionSetId && api.versionSetName) ?
+      api.versionSetName :
+      (api.displayName || api.id);
+  return {key, displayName};
+}
+
+// classifyAzureApiType: APIM api type -> internal type (clients.go). The typed
+// ARM v3 SDK enum has no agentic member, so A2A is detected from the RAW
+// api-type string ("a2a") the untyped REST response returns; fetchApimData
+// additionally treats the presence of properties.a2aProperties as A2A. A2A only
+// arrives via this event path -- the pull engine's typed SDK cannot see it.
+function classifyAzureApiType(rawType) {
+  switch ((rawType || '').toLowerCase()) {
+    case 'soap':
+      return 'soap';
+    case 'websocket':
+      return 'websocket';
+    case 'graphql':
+      return 'graphql';
+    case 'grpc':
+      return 'grpc';
+    case 'odata':
+      return 'odata';
+    case 'a2a':
+    case 'agent':
+      return 'a2a';  // agentic; also detected via a2aProperties in
+                     // fetchApimData
+    default:
+      return 'http';
+  }
+}
+
+// azureSpecSources: which spec(s) to fetch per API type (pipeline.go).
+//   http -> OpenAPI (export); soap -> WSDL (export);
+//   grpc -> proto, graphql -> SDL, odata -> EDMX (inline schema);
+//   websocket -> none. a2a is NOT in this matrix: its Agent Card spec is
+//   fetched from the gateway by fetchA2AAgentCard (called directly from
+//   fetchApimData).
+function azureSpecSources(apiType) {
+  switch (apiType) {
+    case 'http':
+      return [{
+        export: 'openapi+json-link',
+        specTypeId: 'openapi',
+        mimeType: 'application/json',
+        kind: 'openapi'
+      }];
+    case 'soap':
+      return [{
+        export: 'wsdl-link',
+        specTypeId: 'wsdl',
+        mimeType: 'application/wsdl+xml',
+        kind: 'wsdl'
+      }];
+    case 'grpc':
+      return [{
+        schemaContentType: 'text/protobuf',
+        specTypeId: 'proto',
+        mimeType: 'text/plain',
+        kind: 'proto'
+      }];
+    case 'graphql':
+      return [{
+        schemaContentType: 'application/vnd.ms-azure-apim.graphql.schema',
+        specTypeId: 'sdl',
+        mimeType: 'application/graphql',
+        kind: 'graphql'
+      }];
+    case 'odata':
+      return [{
+        schemaContentType: 'application/vnd.ms-azure-apim.odata.schema',
+        specTypeId: 'edmx',
+        mimeType: 'application/xml',
+        kind: 'odata'
+      }];
+    default:
+      return [];
+  }
+}
+
+// ---- AttributeValues builders (mapping.go) -----------------------------
+const enumAttr = (id) => ({enumValues: {values: [{id}]}});
+const jsonAttr = (name, jsonStr) =>
+    ({attribute: name, jsonValues: {values: [jsonStr]}});
+const stringAttr = (name, s) =>
+    ({attribute: name, stringValues: {values: [s]}});
+
+// ---- safe URL logging (clients.go:azureURLHost) -----------------------
+function urlHost(raw) {
+  try {
+    const u = new URL(raw);
+    return u.host ? `${u.protocol}//${u.host}` : '<redacted-url>';
+  } catch {
+    return '<redacted-url>';
+  }
+}
+
+// ---- event parsing (APIM-native) --------------------------------------
+function parseResourceUri(uri) {
+  const m = uri?.match(
+      /subscriptions\/([^/]+)\/resourceGroups\/([^/]+)\/providers\/Microsoft\.ApiManagement\/service\/([^/]+)\/apis\/([^/?]+)/i);
+  return m ? {
+    subscriptionId: m[1],
+    resourceGroup: m[2],
+    serviceName: m[3],
+    apiId: m[4]
+  } :
+             null;
+}
+
+function parseEvent(event) {
+  const t = event?.eventType;
+  if (!t?.startsWith('Microsoft.ApiManagement.API')) return null;
+  const raw = event?.data?.resourceUri ||
+      `${event?.topic || ''}/${event?.subject || ''}`;
+  const scope = parseResourceUri(
+      raw.replace(/\/{2,}/g, '/'));  // collapse // from the topic+subject join
+  if (!scope) return null;
+  return {
+    intent: t.endsWith('Deleted') ? 'delete' : 'upsert',
+    // Best-effort display name hint for the delete path (see deleteRequest).
+    displayNameHint: event?.data?.name || event?.data?.title || '',
+    ...scope,
+  };
+}
+
+// ---- concurrency state gate (best-effort, fail-open) ------------------
+async function actionGate(token) {
+  if (!INSTANCE_ID) return 'PROCEED';
+  try {
+    const url = `${APIHUB_HOST}/v1/${PLUGIN_INSTANCE}/actions/${ACTION_ID}`;
+    const r = await fetch(url, {headers: {Authorization: `Bearer ${token}`}});
+    if (!r.ok) return 'PROCEED';
+    const a = await r.json();
+    if (a.state === 'DISABLED') return 'DROP';
+    if (a.currentExecutionState === 'RUNNING') return 'DEFER';
+  } catch { /* fail-open: pull sync is the safety net */
+  }
+  return 'PROCEED';
+}
+
+// ---- APIM data fetch (ARM REST) ---------------------------------------
+async function armGet(url, token) {
+  const r = await fetch(url, {headers: {Authorization: `Bearer ${token}`}});
+  if (!r.ok) throw new Error(`ARM ${url} -> ${r.status}: ${await r.text()}`);
+  return r.json();
+}
+
+// listNames pages an ARM collection and returns each entry's display name
+// (falling back to its id). Best-effort: a failure yields "" enrichment, never
+// fails the push (clients.go:listAPIProducts / listAPITags).
+async function listNames(url, token, context) {
+  const names = [];
+  let next = url;
+  try {
+    while (next) {
+      const page = await armGet(next, token);
+      for (const v of page.value || []) {
+        const name = v?.properties?.displayName || v?.name;
+        if (name) names.push(name);
+      }
+      next = page.nextLink || null;
+    }
+  } catch (e) {
+    context.log(
+        `enrichment fetch failed (${urlHost(url)}): ${e.message}; continuing`);
+  }
+  return names;
+}
+
+// listGatewayIds pages the service's self-hosted gateways into an array of ids
+// (clients.go:listSelfHostedGateways). The built-in managed gateway is queried
+// separately by its reserved "managed" id and is NOT returned here.
+async function listGatewayIds(url, armToken) {
+  const ids = [];
+  let next = url;
+  while (next) {
+    const page = await armGet(next, armToken);
+    for (const g of page.value || [])
+      if (g?.name) ids.push(g.name);
+    next = page.nextLink || null;
+  }
+  return ids;
+}
+
+// listGatewayApiIds pages a gateway's API collection into a Set of API ids
+// (clients.go:listGatewayAPISet). Throws on ARM error so the caller can decide
+// whether a failed read should demote managed membership.
+async function listGatewayApiIds(url, armToken) {
+  const ids = new Set();
+  let next = url;
+  while (next) {
+    const page = await armGet(next, armToken);
+    for (const v of page.value || [])
+      if (v?.name) ids.add(v.name);
+    next = page.nextLink || null;
+  }
+  return ids;
+}
+
+// fetchGatewayInfo mirrors clients.go:annotateGateways for a single API:
+//   - managedGatewayUrl: the managed gateway base URL (ServiceClient.Get);
+//     "" -> mapping falls back to the conventional <service>.azure-api.net
+//     host.
+//   - managed: whether the managed gateway still serves this API. Demoted to
+//     false ONLY when the managed-gateway API list is read successfully and
+//     omits this API (so a REMOVED gateway drops the Deployment). Fail-safe:
+//     any read error keeps managed=true so a transient ARM error never silently
+//     drops a live API's endpoint.
+//   - selfHosted: ids of self-hosted gateways also serving this API.
+async function fetchGatewayInfo(base, apiId, armToken, context) {
+  let managedGatewayUrl = '';
+  try {
+    const svc =
+        await armGet(`${base}?api-version=${APIM_API_VERSION}`, armToken);
+    managedGatewayUrl = svc?.properties?.gatewayUrl || '';
+  } catch (e) {
+    context.log(
+        `gateway: service get failed: ${e.message}; using conventional host`);
+  }
+
+  let managed = true;
+  try {
+    const managedApis = await listGatewayApiIds(
+        `${base}/gateways/managed/apis?api-version=${APIM_API_VERSION}`,
+        armToken);
+    managed = managedApis.has(apiId);
+  } catch (e) {
+    context.log(
+        `gateway: managed API list failed: ${e.message}; keeping managed=true`);
+  }
+
+  const selfHosted = [];
+  try {
+    for (const gwId of await listGatewayIds(
+             `${base}/gateways?api-version=${APIM_API_VERSION}`, armToken)) {
+      try {
+        const gwApis = await listGatewayApiIds(
+            `${base}/gateways/${encodeURIComponent(gwId)}/apis?api-version=${
+                APIM_API_VERSION}`,
+            armToken);
+        if (gwApis.has(apiId)) selfHosted.push(gwId);
+      } catch (e) {
+        context.log(
+            `gateway: ${gwId} API list failed: ${e.message}; continuing`);
+      }
+    }
+  } catch (e) {
+    context.log(`gateway: self-hosted list failed: ${e.message}; continuing`);
+  }
+
+  return {managed, managedGatewayUrl, selfHosted};
+}
+
+// exportSpec requests an ARM spec export and downloads it from the returned
+// Blob SAS link (clients.go:ExportSpec + azureHoistBody export hoist).
+async function exportSpec(base, apiId, format, armToken, context) {
+  const exp = await armGet(
+      `${base}/apis/${apiId}?export=true&format=${
+          encodeURIComponent(format)}&api-version=${APIM_API_VERSION}`,
+      armToken);
+  const link = exp?.value?.link ||
+      exp?.properties?.value?.link;  // hoist: properties.value -> value
+  if (!link) return null;
+  context.log(
+      `spec export (${format}) for ${apiId} -> SAS host ${urlHost(link)}`);
+  const sr = await fetch(
+      link);  // SAS URL carries the token; never log it, no auth header
+  if (!sr.ok) throw new Error(`spec download HTTP ${sr.status}`);
+  return Buffer.from(await sr.arrayBuffer());
+}
+
+// fetchSchema returns the inline API schema document of the given content type
+// (clients.go:FetchSchema). Returns null when the API has no such schema, so a
+// missing schema degrades to metadata-only.
+async function fetchSchema(base, apiId, contentType, armToken, context) {
+  const list = await armGet(
+      `${base}/apis/${apiId}/schemas?api-version=${APIM_API_VERSION}`,
+      armToken);
+  let schemaId = '';
+  for (const s of list.value || []) {
+    const ct = s?.properties?.contentType || '';
+    if (ct.toLowerCase().includes(contentType.toLowerCase()))
+      schemaId = s.name;  // substring match
+  }
+  if (!schemaId) {
+    context.log(`API ${apiId} has no ${contentType} schema`);
+    return null;
+  }
+  const doc = await armGet(
+      `${base}/apis/${apiId}/schemas/${schemaId}?api-version=${
+          APIM_API_VERSION}`,
+      armToken);
+  const d = doc?.properties?.document || {};
+  const value =
+      d.value || d.odata;  // hoist: document.odata -> document.value (OData)
+  return value ? Buffer.from(value) : null;
+}
+
+// fetchSpecs gathers every spec the API type carries, skipping sources that
+// fail or return no document (pipeline.go:fetchSpecs). Never throws.
+async function fetchSpecs(base, apiId, apiType, armToken, context) {
+  const out = [];
+  for (const src of azureSpecSources(apiType)) {
+    try {
+      const bytes = src.schemaContentType ?
+          await fetchSchema(
+              base, apiId, src.schemaContentType, armToken, context) :
+          await exportSpec(base, apiId, src.export, armToken, context);
+      if (bytes && bytes.length) {
+        out.push({
+          contentsB64: bytes.toString('base64'),
+          specTypeId: src.specTypeId,
+          mimeType: src.mimeType,
+          kind: src.kind
+        });
+      }
+    } catch (e) {
+      context.log(`spec fetch (${src.kind}) failed for ${apiId}: ${
+          e.message}; continuing`);
+    }
+  }
+  return out;
+}
+
+// fetchA2AAgentCard returns the A2A "spec" -- the Agent Card JSON -- as a
+// single spec entry (spec type a2a-agent-card). The card is served by the APIM
+// gateway (a fixed, egress-safe host) at properties.a2aProperties.agentCardPath
+// (default /agent-card.json); A2A gateway APIs are subscriptionRequired=false
+// so the GET is unauthenticated. Best-effort: a miss yields metadata-only (no
+// spec), never throws. Mechanism verified with testing_spec/a2atest.
+async function fetchA2AAgentCard(scope, api, props, context) {
+  try {
+    const a2a = props.a2aProperties || {};
+    const cardPath = a2a.agentCardPath || '/agent-card.json';
+    const card = cardPath.startsWith('/') ? cardPath : '/' + cardPath;
+    const gatewayHost = scope.serviceName.toLowerCase() + '.azure-api.net';
+    const apiPath = (api.path || '').replace(/^\/+|\/+$/g, '');
+    const url = apiPath ? `https://${gatewayHost}/${apiPath}${card}` :
+                          `https://${gatewayHost}${card}`;
+    context.log(`A2A agent card fetch: GET ${url}`);
+    const r = await fetch(url, {headers: {Accept: 'application/json'}});
+    if (!r.ok) {
+      context.log(
+          `A2A agent card GET -> HTTP ${r.status}; publishing metadata-only`);
+      return [];
+    }
+    const bytes = Buffer.from(await r.arrayBuffer());
+    if (!bytes.length) return [];
+    return [{
+      contentsB64: bytes.toString('base64'),
+      specTypeId:
+          'a2a-agent-card',  // A2AAgentCardSystemSpecTypeImmutableAllowedValueID
+      mimeType: 'application/json',
+      kind: 'agent-card',
+    }];
+  } catch (e) {
+    context.log(
+        `A2A agent card fetch failed: ${e.message}; publishing metadata-only`);
+    return [];
+  }
+}
+
+// fetchApimData reads one API (identity from the event scope) into the
+// normalized shape the pull engine produces (clients.go:convertAPIContract +
+// enrichment).
+async function fetchApimData(scope, context) {
+  const armToken = await getAzureToken(ARM_RESOURCE);
+  const apiId = scope.apiId;  // current-revision apiId (as-is)
+  const base =
+      `${ARM_RESOURCE}/subscriptions/${scope.subscriptionId}/resourceGroups/${
+          scope.resourceGroup}` +
+      `/providers/Microsoft.ApiManagement/service/${scope.serviceName}`;
+
+  const apiResp = await armGet(
+      `${base}/apis/${apiId}?api-version=${APIM_API_VERSION}`, armToken);
+  const p = apiResp.properties || {};
+
+  // Version set: prefer the inline object, else resolve the name from the id.
+  let versionSetId = '', versionSetName = '';
+  if (p.apiVersionSet && (p.apiVersionSet.id || p.apiVersionSet.name)) {
+    versionSetId = azureLastSegment(p.apiVersionSet.id || '');
+    versionSetName = p.apiVersionSet.name || '';
+  }
+  if (!versionSetId && p.apiVersionSetId)
+    versionSetId = azureLastSegment(p.apiVersionSetId);
+  if (versionSetId && !versionSetName) {
+    try {
+      const vs = await armGet(
+          `${base}/apiVersionSets/${versionSetId}?api-version=${
+              APIM_API_VERSION}`,
+          armToken);
+      versionSetName = vs?.properties?.displayName || '';
+    } catch (e) {
+      context.log(`version set ${versionSetId} lookup failed: ${
+          e.message}; continuing`);
+    }
+  }
+
+  // A2A detection: the typed ARM v3 SDK cannot model it, but the raw REST
+  // response carries either type=="a2a" or a properties.a2aProperties block.
+  let apiType = classifyAzureApiType(p.type || p.apiType);
+  if (apiType !== 'a2a' && p.a2aProperties) apiType = 'a2a';
+
+  const api = {
+    id: apiId,
+    displayName: p.displayName || '',
+    description: p.description || '',
+    path: (p.path || '').replace(/^\/+/, ''),
+    apiType,
+    revision: p.apiRevision || '',
+    isCurrent: p.isCurrent !== false,
+    version: p.apiVersion || '',
+    versionSetId,
+    versionSetName,
+    subscriptionRequired: !!p.subscriptionRequired,
+    products: await listNames(
+        `${base}/apis/${apiId}/products?api-version=${APIM_API_VERSION}`,
+        armToken, context),
+    tags: await listNames(
+        `${base}/apis/${apiId}/tags?api-version=${APIM_API_VERSION}`, armToken,
+        context),
+  };
+
+  // Gateway membership (managed URL, managed vs. removed, self-hosted) mirrors
+  // clients.go:annotateGateways. Drives whether a Deployment is emitted below.
+  const gw = await fetchGatewayInfo(base, apiId, armToken, context);
+  api.managed = gw.managed;
+  api.managedGatewayUrl = gw.managedGatewayUrl;
+  api.selfHosted = gw.selfHosted;
+
+  // A2A APIs carry no schema resource; their "spec" is the Agent Card served by
+  // the gateway. Everything else uses the export/inline-schema matrix.
+  const specs = api.apiType === 'a2a' ?
+      await fetchA2AAgentCard(scope, api, p, context) :
+      await fetchSpecs(base, apiId, api.apiType, armToken, context);
+  return {api, specs};
+}
+
+// ---- payload builders (mirror mapping.go exactly) ---------------------
+
+// buildVersionMetadata: version attributes + managed-gateway Deployment + specs
+// (mapping.go:buildAzureVersionMetadata / buildAzureDeploymentMetadata /
+// buildAzureSpecMetadata).
+function buildVersionMetadata(scope, api, specs) {
+  const versionId = api.version || SYNTHETIC_VERSION_ID;
+  const resourceUri = azureResourceURI(scope, api.id);
+  const now = nowIso();
+
+  // ----- version-scoped attributes (order-independent; keys are resource
+  // names)
+  const attributes = {};
+  const tagsJSON =
+      (api.tags && api.tags.length) ? JSON.stringify(api.tags) : '';
+  if (tagsJSON) {
+    const n = attributeResourceName(ATTR_TAGS);
+    attributes[n] = jsonAttr(n, tagsJSON);
+  }
+  const productsJSON =
+      (api.products && api.products.length) ? JSON.stringify(api.products) : '';
+  if (productsJSON) {
+    const n = attributeResourceName(ATTR_PRODUCTS);
+    attributes[n] = jsonAttr(n, productsJSON);
+  }
+  if (api.revision) {
+    const n = attributeResourceName(ATTR_REVISION);
+    attributes[n] = stringAttr(n, api.revision);
+  }
+  {
+    const n = attributeResourceName(ATTR_SUBSCRIPTION_REQUIRED);
+    attributes[n] =
+        stringAttr(n, String(!!api.subscriptionRequired));  // always stamped
+  }
+
+  // ----- deployment: managed gateway ONLY (parity with
+  // mapping.go:buildAzureDeploymentMetadata). A version served by no managed
+  // gateway has no reachable endpoint, so NO Deployment is emitted -- the
+  // Version + Spec are still upserted. This is what makes an update that
+  // REMOVES the gateway drop the stale deployment/endpoint on the next push
+  // instead of leaving a dangling endpoint. NOTE: removal takes effect only if
+  // curate replaces a version's deployments on UPSERT (the same assumption the
+  // pull engine relies on). If curate merges deployments, a gateway removal
+  // also needs an explicit deployment DELETE.
+  const deployments = [];
+  if (api.managed) {
+    const gatewayUrl = api.managedGatewayUrl ||
+        ('https://' + scope.serviceName.toLowerCase() + '.azure-api.net');
+    let gatewayHost = gatewayUrl;
+    try {
+      gatewayHost = new URL(gatewayUrl).hostname;
+    } catch { /* keep raw */
+    }
+    const scheme = api.apiType === 'websocket' ? 'wss' : 'https';
+    let endpoint = `${scheme}://${gatewayHost}`;
+    if (api.path) endpoint = `${endpoint}/${api.path.replace(/^\/+/, '')}`;
+
+    // gateway attribute {gateway, gatewayUrl[, selfHosted]}: key order and the
+    // omitempty on selfHosted match Go's json.Marshal of azureGatewayAttr.
+    const gwObj = {gateway: GATEWAY_MANAGED, gatewayUrl};
+    if (api.selfHosted && api.selfHosted.length) {
+      gwObj.selfHosted = api.selfHosted.map((id) => ({id}));
+    }
+    const gatewayAttrName = attributeResourceName(ATTR_GATEWAY);
+
+    deployments.push({
+      deployment: {
+        displayName:
+            scope.serviceName,  // parity: mapping.go uses the service name
+        deploymentType: {
+          attribute: attributeResourceName(SYSTEM_DEPLOYMENT_TYPE_ATTR),
+          enumValues: {values: [{id: DEPLOYMENT_TYPE_ID}]},
+        },
+        resourceUri,
+        managementUrl: {uriValues: {values: [azureManagementURL(scope)]}},
+        endpoints: [endpoint],
+        attributes: {
+          [gatewayAttrName]: jsonAttr(gatewayAttrName, JSON.stringify(gwObj))
+        },
+      },
+      originalId: resourceUri,
+      originalUpdateTime: now,
+    });
+  }
+
+  // ----- specs (0 or 1 per this version, per the spec-source matrix)
+  const specMetas =
+      (specs ||
+       []).map((s) => ({
+                 spec: {
+                   displayName: `${scope.serviceName}-${versionId}`,
+                   specType: enumAttr(s.specTypeId),
+                   contents: {contents: s.contentsB64, mimeType: s.mimeType},
+                 },
+                 originalId:
+                     `${resourceUri}/versions/${versionId}/specs/${s.kind}`,
+                 originalUpdateTime: now,
+               }));
+
+  const vm = {
+    version: {displayName: versionId, attributes},
+    originalId: `${resourceUri}/versions/${versionId}`,
+    originalUpdateTime: now,
+  };
+  if (deployments.length) vm.deployments = deployments;
+  if (specMetas.length) vm.specs = specMetas;
+  return vm;
+}
+
+// buildApiMetadata: one API hub Api (keyed by version-set/base id) carrying the
+// event's version (mapping.go:buildAzureAPIMetadata). Incremental UPSERT: only
+// this version is sent; sibling versions keep their own original_ids untouched.
+function buildApiMetadata(scope, api, versions) {
+  const {key, displayName} = azureGroupKeyAndDisplay(api);
+  return {
+    api: {
+      name: apisResourceName(key),
+      displayName,
+      description: api.description || '',
+      apiStyle: enumAttr(API_STYLE[api.apiType] || API_STYLE.http),
+      // No fingerprint: curate derives one from displayName (mapping.go).
+    },
+    versions,
+    originalId: azureResourceURI(scope, key),
+    originalUpdateTime: nowIso(),
+  };
+}
+
+function upsertRequest(apiMetadata) {
+  return {
+    location: locationResourceName(),
+    collectionType: 'COLLECTION_TYPE_UPSERT',
+    pluginInstance: PLUGIN_INSTANCE,
+    actionId: ACTION_ID,
+    apiData: {apiMetadataList: {apiMetadata: [apiMetadata]}},
+  };
+}
+
+// deleteRequest mirrors the pull reconciler's DELETE op (onramp_diff/diff.go):
+// only api.displayName + originalUpdateTime; curate derives the lookup
+// fingerprint from displayName. The API is already gone, so we cannot re-read
+// its display name; we use the event hint, else the base apiId. Deletes are
+// best-effort here -- the periodic pull sync reconciles authoritatively.
+function deleteRequest(displayName) {
+  return {
+    location: locationResourceName(),
+    collectionType: 'COLLECTION_TYPE_DELETE',
+    pluginInstance: PLUGIN_INSTANCE,
+    actionId: ACTION_ID,
+    apiData: {
+      apiMetadataList:
+          {apiMetadata: [{api: {displayName}, originalUpdateTime: nowIso()}]}
+    },
+  };
+}
+
+async function postCollect(payload, token) {
+  const r = await fetch(COLLECT_URL, {
+    method: 'POST',
+    headers:
+        {Authorization: `Bearer ${token}`, 'Content-Type': 'application/json'},
+    body: JSON.stringify(payload),
+  });
+  const text = await r.text();
+  if (!r.ok) console.error(`collectApiData FAILED ${r.status}: ${text}`);
+  return {ok: r.ok, status: r.status, body: text};
+}
+
+// ---- entry point ------------------------------------------------------
+async function eventGridHandler(event, context) {
+  context.log(`event: ${event?.eventType} subject=${event?.subject}`);
+  const scope = parseEvent(event);
+  if (!scope) return {skipped: 'not an APIM API event'};
+  context.log(
+      `intent=${scope.intent} api=${scope.apiId} svc=${scope.serviceName}`);
+
+  const token = await fetchApiHubToken();
+  const gate = await actionGate(token);
+  if (gate === 'DROP') return {skipped: 'action disabled'};
+  if (gate === 'DEFER')
+    throw new Error('full sync RUNNING - defer via Event Grid retry');
+
+  if (scope.intent === 'delete') {
+    const displayName = scope.displayNameHint || azureBaseAPIID(scope.apiId);
+    const res = await postCollect(deleteRequest(displayName), token);
+    context.log(`delete(displayName=${displayName}) -> ${res.status} ${
+        res.body.slice(0, 500)}`);
+    return res;
+  }
+
+  const {api, specs} = await fetchApimData(scope, context);
+  context.log(
+      `fetched api=${api.id} type=${api.apiType} version=${
+          api.version || SYNTHETIC_VERSION_ID} ` +
+      `versionSet=${api.versionSetId || '-'} managed=${
+          api.managed} selfHosted=${(api.selfHosted || []).length} ` +
+      `specs=${specs.length} products=${api.products.length} tags=${
+          api.tags.length}`);
+  const apiMetadata =
+      buildApiMetadata(scope, api, [buildVersionMetadata(scope, api, specs)]);
+  const res = await postCollect(upsertRequest(apiMetadata), token);
+  context.log(`upsert(originalId=${apiMetadata.originalId}) -> ${res.status} ${
+      res.body.slice(0, 500)}`);
+  return res;
+}
+
+app.eventGrid('onrampApimSync', {handler: eventGridHandler});
+module.exports = {
+  eventGridHandler,
+  parseEvent,
+  classifyAzureApiType,
+  azureSpecSources,
+  azureResourceURI,
+  azureGroupKeyAndDisplay,
+  buildApiMetadata,
+  buildVersionMetadata,
+};

--- a/apihub-plugins/azure/apim/src/functions/onrampApimSync.js
+++ b/apihub-plugins/azure/apim/src/functions/onrampApimSync.js
@@ -213,12 +213,14 @@ const attributeResourceName = (attrId) =>
     `${locationResourceName()}/attributes/${attrId}`;
 
 // ---- identifier parity helpers (grouping.go / clients.go) --------------
-// azureBaseAPIID: strip APIM's ";rev=N" suffix (grouping.go). Do NOT lowercase:
-// the pull path keys resources by the apiId/serviceName as-is.
-const azureBaseAPIID = (id) => {
-  const i = (id || '').indexOf(';rev=');
-  return i >= 0 ? id.slice(0, i) : id;
-};
+// azureBaseAPIID: strip APIM's ";rev=N" suffix (grouping.go). Do NOT lowercase
+// the rest of the id: the pull path keys resources by the apiId/serviceName
+// as-is. The suffix match IS case-insensitive because Event Grid emits ";Rev=N"
+// (capital R) while ARM and the pull path use ";rev=N" -- a case-sensitive
+// match here silently leaves the suffix on, which breaks original_id parity
+// with the pull engine and makes every pushed API look like an orphan to the
+// next reconcile.
+const azureBaseAPIID = (id) => (id || '').replace(/;rev=\d+$/i, '');
 
 // azureLastSegment: final path segment of an ARM resource id (clients.go).
 const azureLastSegment = (s) => {
@@ -347,6 +349,11 @@ function urlHost(raw) {
 }
 
 // ---- event parsing (APIM-native) --------------------------------------
+// The revision suffix is stripped here, once, so every downstream consumer
+// (ARM reads, gateway-membership tests, original_id and deployment
+// resource_uri construction) sees the same base id the pull engine uses. ARM
+// resolves the base id to the current revision, which is what an APICreated /
+// APIUpdated event describes.
 function parseResourceUri(uri) {
   const m = uri?.match(
       /subscriptions\/([^/]+)\/resourceGroups\/([^/]+)\/providers\/Microsoft\.ApiManagement\/service\/([^/]+)\/apis\/([^/?]+)/i);
@@ -354,7 +361,7 @@ function parseResourceUri(uri) {
     subscriptionId: m[1],
     resourceGroup: m[2],
     serviceName: m[3],
-    apiId: m[4]
+    apiId: azureBaseAPIID(m[4])
   } :
              null;
 }
@@ -510,9 +517,19 @@ async function exportSpec(base, apiId, format, armToken, context) {
       `${base}/apis/${apiId}?export=true&format=${
           encodeURIComponent(format)}&api-version=${APIM_API_VERSION}`,
       armToken);
-  const link = exp?.value?.link ||
+  // The SAS link's position in the response varies by api-version: 2024-05-01
+  // returns {link} at the top level, other versions nest it under value or
+  // properties.value. Check all three, outermost first.
+  const link = exp?.link || exp?.value?.link ||
       exp?.properties?.value?.link;  // hoist: properties.value -> value
-  if (!link) return null;
+  if (!link) {
+    // Logged rather than dropped silently: a missing link is indistinguishable
+    // from "API has no spec" at the call site, and the resulting empty catalog
+    // entry is otherwise invisible.
+    context.log(`spec export (${format}) for ${
+        apiId}: no SAS link in response; publishing metadata-only`);
+    return null;
+  }
   context.log(
       `spec export (${format}) for ${apiId} -> SAS host ${urlHost(link)}`);
   const sr = await fetch(
@@ -617,7 +634,9 @@ async function fetchA2AAgentCard(scope, api, props, context) {
 // enrichment).
 async function fetchApimData(scope, context) {
   const armToken = await getAzureToken(ARM_RESOURCE);
-  const apiId = scope.apiId;  // current-revision apiId (as-is)
+  // Base apiId: parseResourceUri already stripped any ";rev=N" suffix, so ARM
+  // resolves this to the current revision and every id we emit matches pull.
+  const apiId = scope.apiId;
   const base =
       `${ARM_RESOURCE}/subscriptions/${scope.subscriptionId}/resourceGroups/${
           scope.resourceGroup}` +


### PR DESCRIPTION
Real-time, event-driven Azure APIM to Apigee API hub on-ramp using Event Grid + an Azure Function with Workload Identity Federation (no client secrets). Complements the existing azure-apim Application Integration sample by offering lower-latency, keyless sync.

What is included:
- README.md walking through setup for two-cloud usage (Azure Cloud Shell, Google Cloud Shell, or local terminal).
- env.sh with the placeholders users fill in before running the scripts.
- azure_setup.sh (App Registration + Bicep deploy + function publish + Event Grid subscription + APIM managed identity).
- gcp_setup.sh (service account, WIF pool/provider, impersonation binding, required APIs).
- cleanup.sh to tear down every resource the sample creates.
- main.bicep for the Function App + storage + plan + user-assigned identity + optional Application Insights + APIM Reader role.
- src/functions/onrampApimSync.js: the Event Grid-triggered sync function.
- host.json, package.json, .gitignore.

The samples table in the root README.md is updated to list the new plugin so the CONTRIBUTING.md check-readme lint passes.